### PR TITLE
Include lampe and peregrine

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,8 +30,9 @@ The plan is to turn this page into a crowd-sourced community resource that can c
 
 * **Computational Neuroscience**: [Training deep neural density estimators to identify mechanistic models of neural dynamics](https://elifesciences.org/articles/56261) by Pedro J Gonçalves, Jan-Matthis Lueckmann, Michael Deistler, Marcel Nonnenmacher, Kaan Öcal, Giacomo Bassetto, Chaitanya Chintaluri, William F Podlaski, Sara A Haddad, Tim P Vogels, David S Greenberg, Jakob H Macke
 
-
 * **Gravitational Wave Astronomy**: [Real-Time Gravitational Wave Science with Neural Posterior Estimation](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.241103) by Maximilian Dax, Stephen R. Green, Jonathan Gair, Jakob H. Macke, Alessandra Buonanno, and Bernhard Schölkopf
+
+* **Gravitational Wave Astronomy**: [Peregrine: Sequential simulation-based inference for gravitational wave signals](https://arxiv.org/abs/2304.02035) by Uddipta Bhardwaj, James Alvey, Benjamin Kurt Miller, Samaya Nissanke, Christoph Weniger
 
 * **Astroparticle Physics**: [Inferring dark matter substructure with astrometric lensing beyond the power spectrum](https://iopscience.iop.org/article/10.1088/2632-2153/ac494a/meta) by Siddharth Mishra-Sharma
 
@@ -64,6 +65,7 @@ An initial list of SBI-related software packages
  * [MadMiner](https://madminer-tool.github.io/madminer-tutorial/tutorial/0_intro.html) - aimed at particle physics
  * [swyft](https://github.com/undark-lab/swyft) (python) the reference implementation of Truncated Marginal Neural Ratio Estimation (TMNRE), an efficient, simulation-based inference technique for complex data and expensive simulators
  * [carl](http://diana-hep.org/carl/) an early NN-based SBI package
+ * [lampe](https://github.com/francois-rozet/lampe) (python) is a flexible, amortized sbi library. The philosophy of LAMPE is to avoid obfuscation and expose all components so it is most useful for researchers.
 
 
 


### PR DESCRIPTION
I have added two items to the main page, namely: 
* An amoritzed simulation-based inference library called [lampe](https://github.com/francois-rozet/lampe) with 60 stars and in active use by sbi algorithm researchers in Liège, Amsterdam, and Paris. It was created by a student of Gilles Louppe.
* a new paper about gravitational wave inference called [peregrine](https://arxiv.org/abs/2304.02035) which has gotten approval from the virgo collaboration (GW detectors) for circulation and submission to physical review D (covering particles, fields, gravitation, and cosmology). It takes a fundamentally different approach than the other suggested gravitational wave astronomy paper (sequential truncation, computation of marginal posteriors) and should be informative for a curious reader. 

I hope you consider adding them! Thanks for your time!
Ben