### PR TITLE
bug fix: duplicating post

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import os
+from pathlib import Path
 from scholar.api import query_arxiv, query_serp
 from scholar.post_maker import make_all
 from scholar.database import create_tables, insert_result
 
 SEARCH_TERM = '"simulation-based+inference"'
+POST_DIR = Path("./_posts/")
 
 
 def crawl(term: str, more_results: bool = False, stop_days: int = None) -> dict:
@@ -39,12 +41,15 @@ def crawl(term: str, more_results: bool = False, stop_days: int = None) -> dict:
 
 
 if __name__ == "__main__":
-    # crawl(SEARCH_TERM)  # For crawling all results (start a new database)
-    crawl(
-        SEARCH_TERM, stop_days=14
-    )  # For crawling only the last 14 days (simulate google scholar alerts)
+    crawl(SEARCH_TERM, stop_days=14)
 
-    make_all(overwrite=False)
+    # The single source of truth is the database, so we can just delete all.
+    # Probably too aggressive.
+    # TODO: Find a better way to avoid post duplicates due to time zone???
+    for post in POST_DIR.glob("*.md"):
+        post.unlink()
+
+    make_all()
 
 
 def reset() -> None:

--- a/scholar/database.py
+++ b/scholar/database.py
@@ -59,6 +59,9 @@ def insert_result(result: dict) -> None:
             Paper.arxiv_category_tag,
             Paper.published_on,
         ],
+        update={
+            Paper.citation_backlink: result["citation_backlink"],
+        },
     ).execute()
 
 

--- a/working.ipynb
+++ b/working.ipynb
@@ -76,74 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Patch category and group tag to database"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import arxiv\n",
-    "\n",
-    "search = arxiv.Search(query=f\"ti:Simulation-based inference\", max_results=1)\n",
-    "result = next(search.results())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result.entry_id.split(\"/\")[-1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def arxiv_to_bibtex(entry):\n",
-    "    bibtex = \"@article{{{},\\n\".format(entry.get(\"id\").replace(\"/\", \"_\"))\n",
-    "\n",
-    "    # Title\n",
-    "    title = entry.get(\"title\").replace(\"\\n\", \" \").replace(\"\\r\", \"\").strip()\n",
-    "    bibtex += \"  title={{ {} }},\\n\".format(title)\n",
-    "\n",
-    "    # Author(s)\n",
-    "    authors = \" and \".join(author.name for author in entry.get(\"authors\"))\n",
-    "    bibtex += \"  author={{ {} }},\\n\".format(authors)\n",
-    "\n",
-    "    # Journal\n",
-    "    bibtex += \"  journal={{ arXiv preprint }},\\n\"\n",
-    "\n",
-    "    # Year\n",
-    "    year = entry.get(\"published\")[:4]\n",
-    "    bibtex += \"  year={{ {} }},\\n\".format(year)\n",
-    "\n",
-    "    # URL\n",
-    "    url = entry.get(\"id\")\n",
-    "    bibtex += \"  url={{ {} }},\\n\".format(url)\n",
-    "\n",
-    "    # eprint (arXiv ID)\n",
-    "    eprint = re.sub(r\"http[s]?://arxiv.org/abs/\", \"\", entry.get(\"id\"))\n",
-    "    bibtex += \"  eprint={{ {} }}\\n\".format(eprint)\n",
-    "\n",
-    "    bibtex += \"}\\n\"\n",
-    "\n",
-    "    return bibtex"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "arxiv_to_bibtex(result)"
+    "## Working"
    ]
   }
  ],


### PR DESCRIPTION
I am unable to determine the cause of the discrepancy in the post's date between server-side generation (using GitHub Actions) and local post generation. This results in two duplicate posts with the same title but differing dates (offset by one day). 

To address this issue, I maintain a single source of truth in the SQLite `scholar/paper.db` and regenerate all the `_post/*.md` files whenever a `daily pull` action is initiated.