### PR TITLE
rollback action token until PAT is created.

### DIFF
--- a/.github/workflows/pull_paper.yml
+++ b/.github/workflows/pull_paper.yml
@@ -51,5 +51,5 @@ jobs:
       name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.PAT}}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         force: true


### PR DESCRIPTION
To avoid action from failing, wait for personal access token to be created.