### PR TITLE
simplify backlink to avoid unnecessary update

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -127,6 +127,21 @@ def query_arxiv(arxiv_id: str) -> arxiv.Result:
     }
 
 
+def format_backlink(url: str) -> str:
+    """Format citation backlink obtained from SERP API."""
+
+    if not url:
+        return None
+
+    # Non-google scholar link returns as is
+    if not "scholar.google" in url:
+        return url
+
+    # Google scholar link remove junks
+    splitted = url.split("&as_sdt")
+    return splitted[0]
+
+
 def format_serp_result(result: dict) -> dict:
     """Format the SERP API results."""
 
@@ -158,6 +173,7 @@ def format_serp_result(result: dict) -> dict:
 
     try:
         citation_backlink = result["inline_links"]["cited_by"]["link"]
+        citation_backlink = format_backlink(citation_backlink)
     except KeyError:
         citation_backlink = None
 

--- a/backend/data/papers.yaml
+++ b/backend/data/papers.yaml
@@ -11,7 +11,7 @@
     \ an approach to perform Bayesian inference to estimate parameters in detailed\
     \ neural models. SBI \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5565541295098586319&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5565541295098586319
   category: Neuroscience
   doi: 10.1101/2023.04.17.537118
 - id: 2
@@ -41,7 +41,7 @@
     \ framework for analyzing galaxy clustering using simulation-based inference.\
     \ In this work, we \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1204951877132903978&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1204951877132903978
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.1088/1475-7516/2023/04/010/meta
 - id: 4
@@ -89,7 +89,7 @@
     \ simulation-based inference approach designed to study broad classes of gravitational\
     \ wave signal\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=13895659792990643892&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13895659792990643892
   arxiv_id: '2304.02035'
   arxiv_category_tag: gr-qc
   category: Physics
@@ -135,7 +135,7 @@
     \ inference to account for the whole error budget. We used the X-COP cluster sample\
     \ to individually \u2026"
   journal: aanda.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17554045131362085212&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17554045131362085212
   category: Astrophysics
   doi: https://www.aanda.org/articles/aa/pdf/forth/aa45779-22.pdf
 - id: 10
@@ -168,7 +168,7 @@
     \ and flexibility of the simulation-based inference methods. We \u2026 of a simulation-based\
     \ inference method based on \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10087386736943123190&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10087386736943123190
   category: Bioinformatics
   doi: 10.1101/2023.03.06.531327
 - id: 12
@@ -185,7 +185,7 @@
     \ inference and event generation, high-granularity detector simulation such as\
     \ at the HL-LHC (High \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1693599676799815557&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1693599676799815557
   arxiv_id: '2303.08046'
   arxiv_category_tag: physics.ins-det
   category: Physics
@@ -203,7 +203,7 @@
     \ while overcoming the \u2026 that explain observed electrophysiology, we used\
     \ simulation-based inference (SBI)25\u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6128980025825657340&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6128980025825657340
   category: Neuroscience
   doi: 10.1101/2023.03.02.530774
 - id: 14
@@ -233,7 +233,7 @@
     \ inference to uncover constraints on the recurrent connectivity that allow E/I\
     \ co-tuning to emerge. We \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6810493978059380896&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6810493978059380896
   category: Neuroscience
   doi: 10.1101/2023.02.27.530253
 - id: 16
@@ -301,7 +301,7 @@
     \ functions and posterior densities arising in Bayesian surrogate modeling and\
     \ simulation-based inference. \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9889389963876965867&as_sdt=800005&sciodt=0,15&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9889389963876965867
   arxiv_id: '2302.09125'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -343,7 +343,7 @@
     \ methods such as Markov Chain Monte Carlo, both for likelihood-based and simulation-based\
     \ inference. \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7010707496353533455&as_sdt=5,39&sciodt=0,39&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7010707496353533455
   arxiv_id: '2302.03026'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -386,7 +386,7 @@
     \ tool for the parameter estimation of mechanistic and simulatable models with\
     \ intractable likelihoods. \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=2335772154176617664&as_sdt=5,36&sciodt=0,36&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2335772154176617664
   arxiv_id: '2301.13368'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -404,7 +404,7 @@
     \ inference, now our SOBER-LFI is also capable of solving simulation-based inference.\
     \ The main \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6154015340046386391&as_sdt=5,36&sciodt=0,36&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6154015340046386391
   arxiv_id: '2301.11832'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -444,7 +444,7 @@
     \ inference methods. The software is available open source with documentation\
     \ and a tutorial at \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5642539770950589088&as_sdt=5,36&sciodt=0,36&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5642539770950589088
   category: Evolutionary biology
   doi: 10.1101/2023.01.11.523690
 - id: 31
@@ -460,7 +460,7 @@
     \ called NPE to perform Bayesian retrievals of exoplanet atmospheres. Unlike the\
     \ commonly used \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8334937977002912374&as_sdt=5,36&sciodt=0,36&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8334937977002912374
   arxiv_id: '2301.06575'
   arxiv_category_tag: astro-ph.EP
   category: Astrophysics
@@ -478,7 +478,7 @@
     \ inference (SBI) to characterize the EM selection criterion in a sample of BNS\
     \ mergers. For an observed \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1669507538115876672&as_sdt=5,36&sciodt=0,36&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1669507538115876672
   arxiv_id: '2301.05241'
   category: Astrophysics
   doi: 10.1093/mnras/stad069
@@ -570,7 +570,7 @@
     \ of transcriptional activity information from the RNA velocity of single cells\
     \ to perform trajectory \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=2625108809264800670&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2625108809264800670
   category: Quantitative Biology
 - id: 42
   created_at: 2023-04-26 10:10:01.639538
@@ -600,7 +600,7 @@
     \ these materials. Textbooks also varied by the extent of coverage of parametric\
     \ methods. For example, the \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4262516242826376192&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4262516242826376192
   category: Education
 - id: 44
   created_at: 2023-04-26 10:10:03.846077
@@ -656,7 +656,7 @@
     \ inference. We introduce theoretically valid and interpretable validation diagnostics\
     \ that scale to both high\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16233832943011069818&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16233832943011069818
   arxiv_id: '2211.09602'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -704,7 +704,7 @@
     \ normalizing flows, trained to rapidly infer the parameters of toy supernovae\
     \ model in multivariate, Rubin\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17210040949417357460&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17210040949417357460
   arxiv_id: '2211.04480'
   arxiv_category_tag: astro-ph.HE
   category: Astrophysics
@@ -750,7 +750,7 @@
     \ are a convenient means to approximating conventional parameter calibration procedures.\
     \ A popular \u2026"
   journal: openreview.net
-  citation_backlink: https://scholar.google.com/scholar?cites=5984859003596420825&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5984859003596420825
   category: Statistics
 - id: 57
   created_at: 2023-04-26 10:10:20.028313
@@ -764,7 +764,7 @@
     \ (SBI), to conduct either amortized or targeted inference from experimental observations\
     \ \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11264366275621914073&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11264366275621914073
   arxiv_id: '2210.14756'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -810,7 +810,7 @@
     \ comparison in high \u2026 facilitates the integration of our methods to simulation-based\
     \ inference workflows. \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=18047987674139003356&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18047987674139003356
   category: Statistics
 - id: 62
   created_at: 2023-04-26 10:10:25.944213
@@ -823,7 +823,7 @@
     \ estimation, resampling, neural networks, spectral analyses, and other simulation-based\
     \ inference \u2026"
   journal: journals.lww.com
-  citation_backlink: https://scholar.google.com/scholar?cites=10865944781745749225&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10865944781745749225
   category: Neuroscience
 - id: 63
   created_at: 2023-04-26 10:10:27.104223
@@ -838,7 +838,7 @@
     \ dubbed the InferoStatic Networks (ISN) method, to model the score and likelihood\
     \ ratio \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4256691065595931960&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4256691065595931960
   arxiv_id: '2210.01680'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -866,7 +866,7 @@
     \ can be illsuited \u2026 We introduce a new method for simulationbased inference\
     \ that enjoys the benefits of \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4340905326075118453&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4340905326075118453
   arxiv_id: '2209.14249'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -920,7 +920,7 @@
     \ repeatedly running a stochastic simulator and inferring posterior distributions\
     \ from model-\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16561248332012832367&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16561248332012832367
   arxiv_id: '2210.04815'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -953,7 +953,7 @@
     \ can produce \u2026 reduce the range of applicability of simulation-based inference.\
     \ For this reason, we \u2026"
   journal: openreview.net
-  citation_backlink: https://scholar.google.com/scholar?cites=6138961182332794768&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6138961182332794768
   arxiv_id: '2110.06581'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -982,7 +982,7 @@
     \ has been made in recent years towards a suite of simulation-based inference\
     \ (SBI) methods \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16688827470381975843&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16688827470381975843
   arxiv_id: '2209.01845'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -999,7 +999,7 @@
     \ that produce posterior approximations p(\u03D1 | x) under the following semantics.\
     \ Target parameters \u03D1 \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=2070151199404142004&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2070151199404142004
   arxiv_id: '2208.13624'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -1014,7 +1014,7 @@
     \ their likelihood function, requiring the use of simulation-based inference,\
     \ such as simulated method of \u2026"
   journal: kent.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=13996944156683755311&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13996944156683755311
   category: Statistics
 - id: 76
   created_at: 2023-04-26 10:10:43.812664
@@ -1086,7 +1086,7 @@
     \ which applies a simulator, a fitted statistical surrogate model, and a set of\
     \ prior beliefs to estimate a \u2026"
   journal: joss.theoj.org
-  citation_backlink: https://scholar.google.com/scholar?cites=2789752983513578176&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2789752983513578176
   category: Computer Science
 - id: 82
   created_at: 2023-04-26 10:10:51.856160
@@ -1101,7 +1101,7 @@
     \ and graph-based machine learning in order to infer the dark matter density profiles\
     \ of dwarf \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=8913784847554083300&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8913784847554083300
   arxiv_id: '2208.12825'
   arxiv_category_tag: astro-ph.CO
   category: Astrophysics
@@ -1298,7 +1298,7 @@
     \ the University of \u2026 While we emphasize simulation-based inference in our\
     \ course, we believe that many \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2247425310749538569&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2247425310749538569
   category: Education
 - id: 100
   created_at: 2023-04-26 10:11:14.428256
@@ -1314,7 +1314,7 @@
     \ how to construct properly calibrated confidence regions for internal parameters\
     \ with nominal conditional \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11065092708730105260&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11065092708730105260
   arxiv_id: '2205.15680'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -1355,7 +1355,7 @@
     \ for determining key evolutionary parameters from observed adaptive dynamics\
     \ in evolution \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1187758372476626714&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1187758372476626714
   category: Quantitative Biology
 - id: 104
   created_at: 2023-04-26 10:11:18.866464
@@ -1369,7 +1369,7 @@
     \ (SBI). It builds on \u2026 , several techniques collectively known as simulation-based\
     \ inference (SBI) have \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=9408830879778530143&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9408830879778530143
   arxiv_id: '2210.11915'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -1417,7 +1417,7 @@
     \ It has been shown that commonly used algorithms can produce overconfident posterior\
     \ \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6096852839922274420&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6096852839922274420
   arxiv_id: '2304.10978'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -1448,7 +1448,7 @@
     \ the angular power spectrum of the distribution of foreground gravitational-wave\
     \ transient events. As a \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=988054112449157708&as_sdt=5,34&sciodt=0,34&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=988054112449157708
   arxiv_id: '2305.02652'
   arxiv_category_tag: astro-ph.CO
   category: Astrophysics
@@ -1491,7 +1491,7 @@
     \ ~\u4E2D\u9AD8\u306E\u63A5\u7D9A\u3082\u8996\u91CE\u306B\u5165\u308C\u3066~ Taking\
     \ Articulation between Junior High and \u2026"
   journal: jstage.jst.go.jp
-  citation_backlink: https://scholar.google.com/scholar?cites=10211091126074178685&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10211091126074178685
   doi: https://www.jstage.jst.go.jp/article/jssep/44/0/44_67/_article/-char/ja/
 - id: 116
   created_at: 2023-05-22 16:54:51.428226
@@ -1530,7 +1530,7 @@
     \ inference and \u2026 The section concludes with a list of difficulties related\
     \ to simulation-based inference that \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10631432974893412267&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10631432974893412267
   category: Education
   doi: https://iase-web.org/ojs/SERJ/article/view/156
 - id: 119
@@ -1572,7 +1572,7 @@
     \ this study is to explore how students use traditional and simulation-based inference\
     \ \u2026 simulation-based inference \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6941266161623576372&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6941266161623576372
   category: Mathematics
   doi: https://iase-web.org/documents/dissertations/16.CatherineCase.Dissertation.pdf
 - id: 122
@@ -1586,7 +1586,7 @@
     \ inference. APT can modify the \u2026 It is more flexible, scalable and efficient\
     \ than previous simulation-based inference \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=9520658637115522401&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9520658637115522401
   category: Statistics
   doi: https://proceedings.mlr.press/v97/greenberg19a.html
 - id: 123
@@ -1601,7 +1601,7 @@
     \ in a climate forced dynamical model of P. falciparum transmission in Colombia.\
     \ Stocks, Theresa1 \u263A; Bernal-\u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=1209365356318205992&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1209365356318205992
   category: Geography
   doi: https://www.researchgate.net/profile/Sebastian-Bernal-Garcia/publication/351116511_Simulation_based_inference_methods_in_a_climate_forced_dynamical_model_of_P_falciparum_transmission_in_Colombia/links/608849f9881fa114b4319bf9/Simulation-based-inference-methods-in-a-climate-forced-dynamical-model-of-P-falciparum-transmission-in-Colombia.pdf
 - id: 124
@@ -1614,7 +1614,7 @@
     \ for the model parameters on an epidemic model that allows tuneable stochasticity.\
     \ To do so, the RV incidence data \u2026"
   journal: zora.uzh.ch
-  citation_backlink: https://scholar.google.com/scholar?cites=935627842606900489&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=935627842606900489
   category: Statistics
   doi: https://www.zora.uzh.ch/id/eprint/152449/1/2015-Kratzer.pdf
 - id: 125
@@ -1628,7 +1628,7 @@
     \ But can a simulation-based inference (SBI) course be flipped? In \u2026 In particular,\
     \ \u201Csimulationbased inference\u201D (SBI) has been \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5959607649704760115&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5959607649704760115
   category: Education
   doi: https://iase-web.org/icots/10/proceedings/pdfs/ICOTS10_C167.pdf
 - id: 126
@@ -1654,7 +1654,7 @@
     \ in the Democratic Republic of Congo and discuss situations in which we think\
     \ simulation-based inference may be \u2026"
   journal: degruyter.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12759319211133460220&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12759319211133460220
   category: Mathematics
   doi: https://www.degruyter.com/document/doi/10.2202/1557-4679.1171/html
 - id: 128
@@ -1668,7 +1668,7 @@
     \ focus on the key concepts in statistical inference instead of getting lost in\
     \ a sea of mathematical algorithms \u2026"
   journal: digitalcollections.dordt.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=16187909265731612511&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16187909265731612511
   category: Education
   doi: https://digitalcollections.dordt.edu/faculty_work/811/
 - id: 129
@@ -1773,7 +1773,7 @@
     \ field-based analytical \u2026 the lognormal cases, b) simulation-based inference\
     \ using these maximally informative nonlinear \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3661398531957397969&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3661398531957397969
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.1088/1475-7516/2021/11/049/meta
 - id: 140
@@ -1876,7 +1876,7 @@
     \ the parameters in the simulation so that the values of {\\em randomly chosen}\
     \ functions of the simulation \u2026"
   journal: ui.adsabs.harvard.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=9969680762955675005&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9969680762955675005
   arxiv_id: '2111.09220'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -1907,7 +1907,7 @@
     \ the general applicability of simulation-based inference algorithms to complex\
     \ robotic tasks and their usefulness to deal \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=138754000315835690&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=138754000315835690
   arxiv_id: '2303.05873'
   arxiv_category_tag: cs.RO
   category: Computer Science
@@ -1993,7 +1993,7 @@
     \ are higher quality and faster using simulation-based inference compared to Metropolis-Hastings.\
     \ This approach \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6931737830976495182&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6931737830976495182
   arxiv_id: '2203.06537'
   arxiv_category_tag: econ.GN
   category: Economics
@@ -2010,7 +2010,7 @@
     \ how the latest advances in neural simulation-based inference can speed up the\
     \ inference time by up to three \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14317329481681639020&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14317329481681639020
   arxiv_id: '2010.12931'
   arxiv_category_tag: astro-ph.IM
   category: Astrophysics
@@ -2105,7 +2105,7 @@
     \ introductory courses was conducted to evaluate the effectiveness of the simulation-based\
     \ inference \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=13177029577787819764&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13177029577787819764
   arxiv_id: '1707.06537'
   arxiv_category_tag: stat.OT
   category: Statistics
@@ -2121,7 +2121,7 @@
     \ for correlation functions can cause significant biases, a problem that is alleviated\
     \ with simulation-based inference; \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13538359388263543948&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13538359388263543948
   category: Astrophysics
   doi: https://academic.oup.com/mnrasl/article-abstract/506/1/L85/6324582
 - id: 174
@@ -2134,7 +2134,7 @@
     \ process seems missing. This book aims at filling this gap; it is concerned with\
     \ simulationbased inference for spatial point \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9431233177662432843&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9431233177662432843
   category: Mathematics
   doi: https://books.google.com/books?hl=en&lr=&id=dBNOHvElXZ4C&oi=fnd&pg=PR13&dq=%22simulation-based%2Binference%22&ots=C8yPvsCHuX&sig=X9OGokmX0EMaf4Wxoi-MDz30kdo
 - id: 175
@@ -2148,7 +2148,7 @@
     \ inference strategies in the late 1980s and early 1990s. These included simulated\
     \ scores, the stochastic expectation-\u2026"
   journal: cambridge.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1265526003516056771&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1265526003516056771
   category: Economics
   doi: https://www.cambridge.org/core/journals/econometric-theory/article/bayesian-inference-based-only-on-simulated-likelihood-particle-filter-analysis-of-dynamic-economic-models/CBB67FA72D9A0B384400193E8D5472B3
 - id: 176
@@ -2178,7 +2178,7 @@
     \ arising in simulation-based inference and systematically investigate the performance\
     \ of the BayesFlow framework \u2026"
   journal: ui.adsabs.harvard.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=4812079485626010900&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4812079485626010900
   category: Computer Science
   doi: https://ui.adsabs.harvard.edu/abs/2021arXi11208866S/abstract
 - id: 178
@@ -2192,7 +2192,7 @@
     \ simultaneously offers \u2026 We perform experiments on a marginalized version\
     \ of the simulation-based inference benchmark \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=2369843407036273624&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2369843407036273624
   category: Statistics
   doi: https://proceedings.neurips.cc/paper/2021/hash/01632f7b7a127233fa1188bd6c2e42e1-Abstract.html
 - id: 179
@@ -2207,7 +2207,7 @@
     \ setting the weights of the GTST-MLD that is used to perform the risk analysis\
     \ of a CPS. An approach is originally \u2026"
   journal: re.public.polimi.it
-  citation_backlink: https://scholar.google.com/scholar?cites=714129606845352977&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=714129606845352977
   category: Computer Science
   doi: https://re.public.polimi.it/handle/11311/1159313
 - id: 182
@@ -2222,7 +2222,7 @@
     \ bias of inferred hyperparameters in simulation-based inference will become significant.\
     \ Therefore, we evaluate the \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=12999798397663441386&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12999798397663441386
   category: Physics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.083014
 - id: 185
@@ -2235,7 +2235,7 @@
   snippet: "\u2026 Indirect inference is part of an increasingly growing tool-kit\
     \ of simulation-based inference procedures. These are often proposed with \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12670896172956680626&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12670896172956680626
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1198/10618600152628347
 - id: 187
@@ -2249,7 +2249,7 @@
     \ paradigm for many disciplines, methodologies, and studies. Already over 170\
     \ disciplines, methodologies, and \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=1213137016767082306&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1213137016767082306
   category: Education
   doi: https://link.springer.com/chapter/10.1007/978-3-030-55867-3_2
 - id: 188
@@ -2263,7 +2263,7 @@
     \ firms set different prices for their goods depending on the destination markets.\
     \ In other words, firms adjust their \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=8618174134504345491&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8618174134504345491
   category: Statistics
   doi: https://link.springer.com/chapter/10.1007/978-1-4757-3613-7_29
 - id: 189
@@ -2277,7 +2277,7 @@
     \ contributes to this stream of research in three ways: (1) it does not require\
     \ simplistic queueing structures and is \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2986856547887550381&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2986856547887550381
   category: Statistics
   doi: https://journals.sagepub.com/doi/pdf/10.1177/00375497211061115
 - id: 190
@@ -2292,7 +2292,7 @@
     \ of simulation-based curriculum in introductory statistics using data from 3,500\
     \ students enrolled in an introductory \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5233893072816399215&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5233893072816399215
   category: Education
   doi: https://www.iase-web.org/ojs/SERJ/article/view/178
 - id: 191
@@ -2318,7 +2318,7 @@
     \ on the limiting \u2026 data example show the promising performance of the proposed\
     \ simulationbased inference. \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=511125452059808852&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=511125452059808852
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11425-020-1798-y
 - id: 193
@@ -2333,7 +2333,7 @@
     \ computation (ABC) 17 \u2026 In principle, simulation-based inference approaches\
     \ extend to these more complicated \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4864613241366748869&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4864613241366748869
   category: Epidemiology
   doi: https://www.nature.com/articles/s41598-022-25018-3
 - id: 194
@@ -2347,7 +2347,7 @@
     \ on generally intractable structural models through an auxiliary model, conceived\
     \ as easier to handle. This \u2026"
   journal: greta.it
-  citation_backlink: https://scholar.google.com/scholar?cites=1520176347057289020&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1520176347057289020
   category: Quantitative Finance
   doi: https://www.greta.it/old/wp/02.01.PDF
 - id: 195
@@ -2376,7 +2376,7 @@
     \ introduced in this paper that will be used in the simulation-based inference\
     \ approach proposed in Section 4. BAPT \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=10642866261725772351&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10642866261725772351
   category: Engineering
   doi: https://www.sciencedirect.com/science/article/pii/S0377221719301419
 - id: 197
@@ -2392,7 +2392,7 @@
     \ neural network architectures circumvent many previous problems of approximate\
     \ Bayesian computation. Moreover, \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8598439204534193600&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8598439204534193600
   arxiv_id: '2005.03899'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -2447,7 +2447,7 @@
     \ on fitting Gaussian Process (GP) surrogate models to limited numbers of realisations\
     \ from the network contagion \u2026"
   journal: researchspace.auckland.ac.nz
-  citation_backlink: https://scholar.google.com/scholar?cites=3992744396224398101&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3992744396224398101
   category: Mathematics
   doi: https://researchspace.auckland.ac.nz/handle/2292/57450
 - id: 203
@@ -2461,7 +2461,7 @@
     \ and often employs either reallocating (as in a randomization test) or resampling\
     \ (as in bootstrapping). Reallocating \u2026"
   journal: ui.adsabs.harvard.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=155979275171338696&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=155979275171338696
   arxiv_id: '1708.02102'
   arxiv_category_tag: math.ST
   category: Mathematics
@@ -2477,7 +2477,7 @@
     \ inference. In this paper, we propose a simulation-based inference algorithm\
     \ in which we iteratively update \u2026"
   journal: openreview.net
-  citation_backlink: https://scholar.google.com/scholar?cites=13719404802311382575&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13719404802311382575
   category: Computer Science
   doi: https://openreview.net/forum?id=svH3klEbuXa
 - id: 205
@@ -2505,7 +2505,7 @@
     \ the physical information produced by observation and interaction with the evolving\
     \ dynamic environment. We \u2026"
   journal: psyarxiv.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14147629209615998884&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14147629209615998884
   category: Computer Science
   doi: https://psyarxiv.com/6vr4g/download?format=pdf
 - id: 207
@@ -2519,7 +2519,7 @@
     \ surveys depends on the degree of spatial clustering in the animal population.\
     \ To quantify the clustering we \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=13672749772543348759&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13672749772543348759
   category: Statistics
   doi: https://link.springer.com/article/10.1198/108571106X130557
 - id: 208
@@ -2534,7 +2534,7 @@
     \ computational biology\u2014either within likelihood-free [17] or approximate-likelihood\
     \ [16] approaches\u2014 even with the \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16599330864028085807&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16599330864028085807
   category: Quantitative Biology
   doi: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005841
 - id: 209
@@ -2561,7 +2561,7 @@
     \ 3, can be used to overcome the poor finite sample performance of the LR tests\
     \ based on asymptotic critical values. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=582791037117479781&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=582791037117479781
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1002/jae.1138
 - id: 211
@@ -2590,7 +2590,7 @@
     \ Here we report findings from a multi-\u2026 BACKGROUND \u201CSimulation-based\
     \ inference\u201D (SBI) has been gaining in popularity in \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8724779173309933016&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8724779173309933016
   category: Education
   doi: https://iase-web.org/icots/10/proceedings/pdfs/ICOTS10_C177.pdf
 - id: 214
@@ -2652,7 +2652,7 @@
     \ logistic regression, exploiting two novel results for scale mixtures of normals.\
     \ By carefully choosing a hierarchical \u2026"
   journal: projecteuclid.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5147463355682154735&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5147463355682154735
   category: Statistics
   doi: https://projecteuclid.org/journals/bayesian-analysis/volume-7/issue-3/Simulation-based-Regularized-Logistic-Regression/10.1214/12-BA719
 - id: 223
@@ -2680,7 +2680,7 @@
     \ was inefficient for the \u2026 This considerably improved the simulation based\
     \ inference of DBNs with 80% effective \u2026"
   journal: hal.science
-  citation_backlink: https://scholar.google.com/scholar?cites=11312544452541709088&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11312544452541709088
   category: Quantitative Biology
   doi: https://hal.science/hal-01245034/
 - id: 225
@@ -2705,7 +2705,7 @@
     )) = 0, from which an estimator of \u03B8 is deduced. In many econometric models,\
     \ the moment restrictions can not be evaluated \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=10181451439174306392&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10181451439174306392
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1198/073500102288618621
 - id: 228
@@ -2745,7 +2745,7 @@
     \ and the module on resampling and other simulationbased inference are given in\
     \ the following. After that, two other \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=6847302165460008252&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6847302165460008252
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1198/000313002173
 - id: 232
@@ -2759,7 +2759,7 @@
     \ inference is less than for axiomatizing the respective functionality. Additionally,\
     \ details of investigated problems \u2026"
   journal: ias.in.tum.de
-  citation_backlink: https://scholar.google.com/scholar?cites=6677329232861566810&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6677329232861566810
   category: Robotics
   doi: https://ias.in.tum.de/_media/spezial/bib/kunze11naivephysics.pdf
 - id: 233
@@ -2773,7 +2773,7 @@
     \ the use of more pragmatic, flexible models using Bayesian hierarchical models\
     \ (BHM) and simulation based inference \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=269351833941425073&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=269351833941425073
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s10687-009-0092-8
 - id: 234
@@ -2801,7 +2801,7 @@
     \ Our method is not a simulation-based inference procedure \u2026 SFGCIs, is not\
     \ a simulation-based inference procedure and \u2026"
   journal: dergipark.org.tr
-  citation_backlink: https://scholar.google.com/scholar?cites=504394484226129053&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=504394484226129053
   category: Statistics
   doi: https://dergipark.org.tr/en/pub/hujms/issue/38251/442310
 - id: 236
@@ -2815,7 +2815,7 @@
   snippet: "\u2026 Student performance in curricula centered on simulation-based inference:\
     \ A preliminary report. Journal of Statistics Education, 24(3), 114126. \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=2316698653424791126&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2316698653424791126
   category: Education
   doi: https://iase-web.org/icots/10/proceedings/pdfs/ICOTS10_C211.pdf
 - id: 237
@@ -2829,7 +2829,7 @@
     \ inference for POMP models (\u2026 Here, we are concerned with full information,\
     \ frequentist, simulation-based inference. The \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=15097612774175949759&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15097612774175949759
   category: Mathematics
   doi: https://link.springer.com/article/10.1007/s11222-016-9711-9
 - id: 238
@@ -2843,7 +2843,7 @@
     \ inference with pair repulsion models, it is necessary to move point locations\
     \ around. This is not needed with \u2026"
   journal: cambridge.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10338858359530965638&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10338858359530965638
   category: Mathematics
   doi: https://www.cambridge.org/core/journals/advances-in-applied-probability/article/likelihoodbased-inference-for-matern-typeiii-repulsive-point-processes/2FBFB4E299E9CC88C989281D8C16EF64
 - id: 239
@@ -2856,7 +2856,7 @@
     \ inference \u2022 Programming skills built up manipulating dataframes, applied\
     \ to inference and crossvalidation \u2026"
   journal: cs.toronto.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=13625908526406351867&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13625908526406351867
   category: Computer Science
   doi: http://www.cs.toronto.edu/~guerzhoy/icer2019.pdf
 - id: 240
@@ -2870,7 +2870,7 @@
     \ on dynamic, adaptive contact networks. Network evolution is formulated as a\
     \ link-Markovian process, \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=15240300501020564023&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15240300501020564023
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/01621459.2020.1790376
 - id: 241
@@ -2886,7 +2886,7 @@
     \ it allows us to estimate \u2026 the practical limitation of simulation-based\
     \ inference techniques to applications with a low-\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16795873179513710384&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16795873179513710384
   arxiv_id: '2011.05991'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -2902,7 +2902,7 @@
     \ picking and dexterous manipulation. Yet, multi-fingered grippers remain challenging\
     \ to control because of \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15715069352965927762&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15715069352965927762
   arxiv_id: '2109.14275'
   arxiv_category_tag: cs.RO
   category: Computer Science
@@ -2929,7 +2929,7 @@
     \ of estimating financial time series models that are widely used in financial\
     \ economics. The simulation-\u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=16887702204185762606&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16887702204185762606
   category: Quantitative Finance
   doi: https://link.springer.com/chapter/10.1007/978-3-642-17254-0_15
 - id: 245
@@ -2943,7 +2943,7 @@
     \ for the NAO-robot and actively used by the team Berlin United at the RoboCup\
     \ competitions for several years. \u2026"
   journal: informatik.hu-berlin.de
-  citation_backlink: https://scholar.google.com/scholar?cites=8376629124779267960&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8376629124779267960
   category: Robotics
   doi: https://www2.informatik.hu-berlin.de/~mellmann/content/publications/data/HSR-MellmannSchlotter-17.pdf
 - id: 246
@@ -2958,7 +2958,7 @@
     \ inference called \u2026 In this work we have illustrated how a novel technique\
     \ in simulation-based inference (sbi) \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1337496025069190699&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1337496025069190699
   category: Physics
   doi: https://iopscience.iop.org/article/10.1088/1475-7516/2022/09/004/meta
 - id: 247
@@ -3025,7 +3025,7 @@
     \ to simulation-based inference via Monte Carlo EM or MCMC (Golinelli et al.,\
     \ 2006) and asymptotic approximations, such \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=7911640156693106579&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7911640156693106579
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/biom.12352
 - id: 253
@@ -3039,7 +3039,7 @@
   snippet: "\u2026 Simulation-based inference is also proposed and implemented in\
     \ a user-friendly R package. \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=12756127926085539556&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12756127926085539556
   category: Statistics
   doi: https://link.springer.com/article/10.1186/s12874-022-01585-x
 - id: 254
@@ -3053,7 +3053,7 @@
     \ and simulation based inference. The current chapter focuses on simulation based\
     \ inference of hidden Markov \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=6047787560012065149&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6047787560012065149
   category: Mathematics
   doi: https://onlinelibrary.wiley.com/doi/pdf/10.1002/9780470685853#page=225
 - id: 255
@@ -3081,7 +3081,7 @@
     \ challenge frequently encountered in constructing new estimators or in implementing\
     \ a classical one such \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=15588178043349257393&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15588178043349257393
   category: Computer Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/01621459.2017.1380031
 - id: 257
@@ -3107,7 +3107,7 @@
     \ (eg bootstrapping \u2026 Simulation-based inference in mosaic: what if we had\
     \ a different sample? So let us build a \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=5275812313267148530&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5275812313267148530
   category: Education
   doi: https://link.springer.com/chapter/10.1007/978-3-030-25147-5_9
 - id: 259
@@ -3122,7 +3122,7 @@
     \ as we propose in (2) might suggest that the aim of abc lies in an accurate modelling\
     \ of the error distribution g(y | x), ie \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16320241637083330428&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16320241637083330428
   arxiv_id: '2011.08644'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -3150,7 +3150,7 @@
     \ driver and pedestrian perceptual models using naturalistic driving data. Perceptual\
     \ models provide links between \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1322823416602076113&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1322823416602076113
   category: Engineering
   doi: https://ieeexplore.ieee.org/abstract/document/9745572/
 - id: 262
@@ -3164,7 +3164,7 @@
     \ based inference and normalizing flow based matrix element modeling, with capabilities\
     \ enabled uniquely with \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9023626563183647224&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9023626563183647224
   category: Physics
   doi: https://iopscience.iop.org/article/10.1088/1742-6596/2438/1/012137/meta
 - id: 263
@@ -3179,7 +3179,7 @@
     \ schemes based on Gibbs sampling with data augmentation are proposed to conduct\
     \ simulation-based inference \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=6113242019031742429&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6113242019031742429
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/sjpe.12081
 - id: 264
@@ -3193,7 +3193,7 @@
     \ conceptual understanding in modern post-secondary statistics courses (eg, simulation-based\
     \ inference). In this paper \u2026"
   journal: digitalcollections.dordt.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=7253265314364156800&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7253265314364156800
   category: Education
   doi: https://digitalcollections.dordt.edu/faculty_work/1246/
 - id: 265
@@ -3207,7 +3207,7 @@
     \ compare performance with simulation-based inference on two distinct complex\
     \ decision tasks. \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=323123969965936228&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=323123969965936228
   category: Computer Science
   doi: https://proceedings.neurips.cc/paper/2015/hash/ed4227734ed75d343320b6a5fd16ce57-Abstract.html
 - id: 266
@@ -3234,7 +3234,7 @@
     \ inference procedure which allows one to construct tests with provably exact\
     \ levels in situations where the distribution of \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=723628859458944340&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=723628859458944340
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0169716119300367
 - id: 268
@@ -3274,7 +3274,7 @@
     \ estimate the SVNS model using simulation-based inference. The SVNS model is\
     \ applied to monthly US zero-\u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=15712630269396607402&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15712630269396607402
   category: Quantitative Finance
   doi: https://www.sciencedirect.com/science/article/pii/S0167947310002768
 - id: 271
@@ -3287,7 +3287,7 @@
     \ relationship between foreign direct investment and gross domestic product in\
     \ China for the 1982\u20132008 period, both in a \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17251062830536230915&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17251062830536230915
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0264999312003860
 - id: 272
@@ -3316,7 +3316,7 @@
     \ by proposing a particle analogue of this scheme for performing exact, simulation\
     \ based inference for the MJP parameters. \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=6987760844907854352&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6987760844907854352
   category: Mathematics
   doi: https://link.springer.com/article/10.1007/s11222-014-9469-x
 - id: 274
@@ -3330,7 +3330,7 @@
     \ for performing inference on complex simulation models with intractable likelihood\
     \ functions. A common bottleneck \u2026"
   journal: openreview.net
-  citation_backlink: https://scholar.google.com/scholar?cites=14006622158354546652&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14006622158354546652
   category: Statistics
   doi: https://openreview.net/forum?id=OOlxsoRPyFL
 - id: 275
@@ -3345,7 +3345,7 @@
     \ effects, can simulation-based inference with neural networks \u2026 We find\
     \ that our simulation-based inference approach is \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16549376098117763386&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16549376098117763386
   category: Astronomy
   doi: https://iopscience.iop.org/article/10.3847/1538-4357/aca525/meta
 - id: 276
@@ -3359,7 +3359,7 @@
     \ century, which we categorize as: counterfactual causal inference, bootstrapping\
     \ and simulation-based inference, \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2556603999758461985&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2556603999758461985
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/01621459.2021.1938081
 - id: 277
@@ -3374,7 +3374,7 @@
     \ especially, the specific problem of inferring patient discharge times, which\
     \ seems to be a widespread example of \u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10439652969814224672&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10439652969814224672
   category: Medicine
   doi: https://dl.acm.org/doi/abs/10.1145/2000494.2000497
 - id: 278
@@ -3388,7 +3388,7 @@
     \ the simulation-based inference benchmark, namely SLCP, Two Moons, and Gaussian\
     \ Mixture [44]. SLCP is a difficult \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=10243773059505759044&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10243773059505759044
   category: Computer Science
   doi: https://proceedings.neurips.cc/paper_files/paper/2022/hash/159f7fe5b51ecd663b85337e8e28ce65-Abstract-Conference.html
 - id: 279
@@ -3428,7 +3428,7 @@
     \ offers considerable conceptual advantages over more traditional methods for\
     \ inverse parameter estimation, can be \u2026"
   journal: bg.copernicus.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5713262860042845797&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5713262860042845797
   category: Ecology
   doi: https://bg.copernicus.org/articles/11/1261/2014/
 - id: 282
@@ -3455,7 +3455,7 @@
     \ either be in performing a simulation-based inference like the above in which\
     \ ratios are in use, or in adopting OLS \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=3632684675415352390&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3632684675415352390
   category: Quantitative Finance
   doi: https://journals.sagepub.com/doi/pdf/10.1177/0312896211429159
 - id: 284
@@ -3470,7 +3470,7 @@
     \ in cases where exact densities of random variables are intractable, but their\
     \ moment generating functions are readily \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=14335502598590867757&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14335502598590867757
   category: Mathematics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/biom.13030
 - id: 285
@@ -3484,7 +3484,7 @@
     \ inference. The first proposed approximation is fast to compute and is \u2018\
     practically sufficient\u2019, meaning that results \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=13782200978854988091&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13782200978854988091
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9469.2008.00621.x
 - id: 287
@@ -3503,7 +3503,7 @@
     \ form of Gaussian process with likelihood-free inference, which is the regime\
     \ of problems that simulation-based inference is \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5790287534556149623&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5790287534556149623
   arxiv_id: '2112.03235'
   arxiv_category_tag: cs.AI
   category: Computer Science
@@ -3518,7 +3518,7 @@
     \ approach did not occur until computational developments in the late 20th century\
     \ allowed for simulation-based inference \u2026"
   journal: escholarship.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4980692894619202559&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4980692894619202559
   category: Statistics
   doi: https://escholarship.org/content/qt595728vb/qt595728vb_noSplash_91d7fb228a9c682b6a1afbada70d429c.pdf
 - id: 291
@@ -3532,7 +3532,7 @@
     \ models of stochastic volatility defined by heavy-tailed Student-t distributions\
     \ (with unknown degrees of freedom) \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=13500790023028275893&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13500790023028275893
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407601001373
 - id: 292
@@ -3561,7 +3561,7 @@
     \ neural network architectures, we introduce a novel method to search for global\
     \ dark matter-induced gravitational \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10875271906517967859&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10875271906517967859
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.1088/2632-2153/ac494a/meta
 - id: 294
@@ -3575,7 +3575,7 @@
     \ on P2 via updating particles, and an acceleration method that speeds up all\
     \ such particle-simulation-based inference \u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=95987527536291733&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=95987527536291733
   category: Statistics
   doi: https://www.researchgate.net/profile/Chang-Liu-165/publication/326222852_Accelerated_First-order_Methods_on_the_Wasserstein_Space_for_Bayesian_Inference/links/5b5139820f7e9b240ff09a66/Accelerated-First-order-Methods-on-the-Wasserstein-Space-for-Bayesian-Inference.pdf
 - id: 295
@@ -3589,7 +3589,7 @@
     \ machine learning to event generation and simulation-based inference, including\
     \ conceptional developments driven by the \u2026"
   journal: scipost.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14663748530901499682&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14663748530901499682
   category: Physics
   doi: https://www.scipost.org/SciPostPhys.14.4.079?acad_field_slug=chemistry
 - id: 296
@@ -3618,7 +3618,7 @@
     \ The first is consistency: how to generate simulation paths that are consistent\
     \ with available ED data. Another important \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3831061212913844631&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3831061212913844631
   category: Medicine
   doi: https://ieeexplore.ieee.org/abstract/document/5429416/
 - id: 298
@@ -3633,7 +3633,7 @@
     \ to the problem of substructure inference in galaxy\u2013galaxy strong lenses.\
     \ By leveraging additional information \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6844911124102933669&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6844911124102933669
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.3847/1538-4357/ab4c41/meta
 - id: 299
@@ -3647,7 +3647,7 @@
     \ utilizing R and various R \u2026 The next essential ingredient in our teaching\
     \ cocktail is simulation-based inference (SBI). In \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=13522230875502464784&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13522230875502464784
   category: Education
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/test.12264
 - id: 300
@@ -3662,7 +3662,7 @@
     likelihood-free\u2019 inference (read: intractable likelihood)\u2014aka simulation-based\
     \ inference or, in the Bayesian case, \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=4547614370550632838&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4547614370550632838
   category: Mathematics
   doi: http://proceedings.mlr.press/19/kersting20a.html
 - id: 301
@@ -3676,7 +3676,7 @@
     \ the use of sequential simulation techniques to make inference on business cycle\
     \ models and provide an \u2026"
   journal: iris.unive.it
-  citation_backlink: https://scholar.google.com/scholar?cites=16163253073342904014&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16163253073342904014
   category: Statistics
   doi: https://iris.unive.it/handle/10278/32900
 - id: 302
@@ -3691,7 +3691,7 @@
     \ inference of the parameters of the stochastic model under study. Section 4 presents\
     \ the practical example of the \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17391059348569993824&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17391059348569993824
   category: Engineering
   doi: https://www.sciencedirect.com/science/article/pii/S002954932100515X
 - id: 303
@@ -3705,7 +3705,7 @@
     \ environment (de Valpine et al., 2017) that enable simulation-based inference\
     \ for general nonparametric \u2026"
   journal: par.nsf.gov
-  citation_backlink: https://scholar.google.com/scholar?cites=345679477312575526&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=345679477312575526
   category: Statistics
   doi: https://par.nsf.gov/servlets/purl/10111139
 - id: 304
@@ -3719,7 +3719,7 @@
     \ based inference for dynamic econometric models. Then we focus (Chapter 6) on\
     \ stochastic volatility models with \u2026"
   journal: Citeseer
-  citation_backlink: https://scholar.google.com/scholar?cites=7138475869838093713&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7138475869838093713
   category: Quantitative Finance
   doi: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=5ae09f4b6257e09626765e2128e1f78ecdd34df6
 - id: 305
@@ -3732,7 +3732,7 @@
     \ to the core functionality related to descriptive statistics, visualization,\
     \ modeling, and simulation-based inference \u2026"
   journal: digitalcommons.calvin.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=4217564848685856939&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4217564848685856939
   category: Education
   doi: https://digitalcommons.calvin.edu/calvin_facultypubs/252/
 - id: 306
@@ -3746,7 +3746,7 @@
     \ a sound statistical framework is the recent growth of simulation-based inference\
     \ techniques 1 based on neural \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=976034476608349505&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=976034476608349505
   category: Computer Science
   doi: https://www.nature.com/articles/s42254-022-00498-4
 - id: 307
@@ -3760,7 +3760,7 @@
     \ of procedures, but instead are shown the general framework and asked to describe\
     \ their own reasons for their \u2026"
   journal: icots.info
-  citation_backlink: https://scholar.google.com/scholar?cites=17609897683423020527&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17609897683423020527
   category: Education
   doi: http://icots.info/icots/8/cd/pdfs/contributed/ICOTS8_C208_GOULD.pdf
 - id: 308
@@ -3774,7 +3774,7 @@
     \ used for simulation, which in turn means a generative model readily can be employed\
     \ in simulation-based inference \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18007066366700690210&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18007066366700690210
   category: Computer Science
   doi: https://books.google.com/books?hl=en&lr=&id=P28ll-6ozyEC&oi=fnd&pg=PA257&dq=%22simulation-based%2Binference%22&ots=R0q0RUB4TV&sig=yCYp-vhMDFHut2V8C-i36Lf6i38
 - id: 309
@@ -3787,7 +3787,7 @@
     \ selection, including consideration of latent factor and two-part models as well\
     \ as simulation-based inference and \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=6655942443023320772&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6655942443023320772
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=qVEwBQAAQBAJ&oi=fnd&pg=PR15&dq=%22simulation-based%2Binference%22&ots=RNklnk9f0a&sig=5UPwkU0bCHQfgjJlVUXhnSaJVf0
 - id: 310
@@ -3827,7 +3827,7 @@
     \ machine learning, but successful probabilistic programming systems require flexible,\
     \ generic and efficient \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=11803241473159708991&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11803241473159708991
   category: Computer Science
   doi: http://proceedings.mlr.press/v84/ge18b.html?ref=https://githubhelp.com
 - id: 313
@@ -3842,7 +3842,7 @@
     \ models, and therefore is a simulationbased inference method that only requires\
     \ simulations from a generative \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=12956564362327319263&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12956564362327319263
   arxiv_id: '2102.06522'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -3857,7 +3857,7 @@
     \ domains from physical sciences and beyond. While the Bayesian framework lends\
     \ itself well to inverse problems\u2026"
   journal: ml4physicalsciences.github.io
-  citation_backlink: https://scholar.google.com/scholar?cites=10538548945119531270&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10538548945119531270
   category: Statistics
   doi: https://ml4physicalsciences.github.io/2020/files/NeurIPS_ML4PS_2020_112.pdf
 - id: 316
@@ -3872,7 +3872,7 @@
     \ (known) closed-form analytical expression or is computationally intractable,\
     \ simulation-based inference provides an \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=18234072032493840897&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18234072032493840897
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/test.12156
 - id: 317
@@ -3886,7 +3886,7 @@
     \ networks to estimate posterior probability distributions over the full range\
     \ of observations. Once trained, it requires no \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5400080307781002287&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5400080307781002287
   category: Computer Science
   doi: https://iopscience.iop.org/article/10.3847/1538-4357/ac7b84/meta
 - id: 318
@@ -3912,7 +3912,7 @@
     \ in structural discrete\u2013continuous choice models, namely that the simulated\
     \ trajectories are discontinuous functions of \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=1581472481842696577&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1581472481842696577
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407618300502
 - id: 320
@@ -3928,7 +3928,7 @@
     \ is a powerful approach to solving inverse problems in science. However, these\
     \ methods typically treat the \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=737567940759599258&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=737567940759599258
   arxiv_id: '2111.13139'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -3943,7 +3943,7 @@
     \ inference based on the conditional likelihood L c (\u03B8) in (8) where we compare\
     \ the results obtained by using the \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=4375176041029114155&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4375176041029114155
   category: Mathematics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9469.2009.00660.x
 - id: 322
@@ -3956,7 +3956,7 @@
     \ regression setting, how to monitor convergence of the Markov chains and how\
     \ to use simulation-based inference \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2049374657255812678&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2049374657255812678
   category: Statistics
   doi: https://journals.sagepub.com/doi/pdf/10.1177/1471082X18759140
 - id: 323
@@ -3970,7 +3970,7 @@
     \ (SBI) based on normalizing flows to Bayesian hierarchical models. We validate\
     \ quantitatively our proposal on a \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=65503754638557364&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=65503754638557364
   category: Computer Science
   doi: https://proceedings.neurips.cc/paper/2021/hash/6fbd841e2e4b2938351a4f9b68f12e6b-Abstract.html
 - id: 324
@@ -3984,7 +3984,7 @@
     \ neural posterior estimation (NPE) has been successfully used to analyse simulated\
     \ and real galaxy photometry both \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17324009293896476557&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17324009293896476557
   category: Astronomy
   doi: https://iopscience.iop.org/article/10.1088/2632-2153/ac98f4/meta
 - id: 325
@@ -4000,7 +4000,7 @@
     \ to simulation-based inference [27, 28], where the problem of inverse inference\
     \ resembles a supervised learning task. \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6119554108768579577&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6119554108768579577
   category: Medicine
   doi: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1009472
 - id: 326
@@ -4014,7 +4014,7 @@
     \ Alongside advancements in simulation-based inference, \u2026 latest ideas from\
     \ simulation-based inference and uncertainty \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11130332220771263843&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11130332220771263843
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9612724/
 - id: 327
@@ -4028,7 +4028,7 @@
     \ inference and forecasting without implementing nonlinear estimation techniques\
     \ such as ML which is usually \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=9579556356450229953&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9579556356450229953
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/00949655.2014.925898
 - id: 328
@@ -4042,7 +4042,7 @@
     \ be considered, simulation-based inference, such as Markov chain Monte Carlo,\
     \ is not feasible. Therefore, we derive an \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=15039388413323244639&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15039388413323244639
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9892.2005.00460.x
 - id: 329
@@ -4057,7 +4057,7 @@
     \ yielding ill-conditioned likelihood-based estimation tools or computationally\
     \ infeasible simulation-based inference \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=7051706586908198578&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7051706586908198578
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0168927422001118
 - id: 330
@@ -4071,7 +4071,7 @@
     \ estimators in latent variable models. The proposed method integrates a recently\
     \ developed sampling \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=1476693320826998199&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1476693320826998199
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947306000533
 - id: 331
@@ -4084,7 +4084,7 @@
     \ process to perform simulation based inference for the People's Republic of China.\
     \ Our study covers the 1971\u20132007 \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=4367242982566809311&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4367242982566809311
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0301421511009062
 - id: 332
@@ -4099,7 +4099,7 @@
     \ simple problems where the form of the likelihood is known, DELFI offers a fast\
     \ alternative to Markov Chain Monte Carlo (\u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12169728783548368174&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12169728783548368174
   category: Physics
   doi: https://academic.oup.com/mnras/article-abstract/488/3/4440/5532683
 - id: 333
@@ -4115,7 +4115,7 @@
     \ Bayesian identification using the simulation-based inference method. Finally,\
     \ in Section 6, we provide the application \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=3560805921173299342&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3560805921173299342
   category: Epidemiology
   doi: https://www.sciencedirect.com/science/article/pii/S0025556422000219
 - id: 335
@@ -4129,7 +4129,7 @@
   snippet: "\u2026 We also demonstrate advantages over two alternative methods of\
     \ simulation-based inference. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=9442788587044255939&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9442788587044255939
   category: Statistics
   doi: https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9868.2011.01010.x
 - id: 337
@@ -4144,7 +4144,7 @@
     \ that it is not simulation-based inference) and the two others are based on a\
     \ parametric bootstrap approach. The \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=6914660652395324814&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6914660652395324814
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/00949655.2016.1225742
 - id: 338
@@ -4158,7 +4158,7 @@
     \ and ensemble methods, to produce higher fidelity response surfaces with competitive\
     \ out-of-sample predictive \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=5092920980087076951&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5092920980087076951
   category: Statistics
   doi: https://wires.onlinelibrary.wiley.com/doi/abs/10.1002/widm.1094
 - id: 339
@@ -4172,7 +4172,7 @@
     \ and is assessed by Markov-chain Monte Carlo simulation-based inference. The\
     \ inversion model is evaluated \u2026"
   journal: pubs.geoscienceworld.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4675153573788975974&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4675153573788975974
   category: Physics
   doi: https://pubs.geoscienceworld.org/geophysics/article-abstract/75/4/R93/303232
 - id: 340
@@ -4187,7 +4187,7 @@
     \ Bayesian inference for parameters governing stochastic kinetic models defined\
     \ as Markov (jump) \u2026"
   journal: mas.ncl.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=16896677155648360464&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16896677155648360464
   category: Quantitative Biology
   doi: http://www.mas.ncl.ac.uk/~nag48/emMJPpaper2.pdf
 - id: 341
@@ -4213,7 +4213,7 @@
     \ contingent-claims whose values are dependent on some other underlying financial\
     \ assets. In the literature the \u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18255356568345136774&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18255356568345136774
   category: Mathematics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=954569
 - id: 343
@@ -4228,7 +4228,7 @@
     \ efficient simulation-based inference method, that can easily be transferred\
     \ from model to model. \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=7491751822740072109&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7491751822740072109
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0025556421000353
 - id: 344
@@ -4242,7 +4242,7 @@
     \ and simulation based inference. The method can be viewed as a further development\
     \ of SiZer technology, \u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=13918305551258655243&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13918305551258655243
   category: Computer Science
   doi: https://www.researchgate.net/profile/Leena-Ruha/publication/238565967_BAYESIAN_ANALYSIS_OF_IMAGE_DIFFERENCES_IN_MULTIPLE_SCALES/links/02e7e537ecc7e65ca0000000/BAYESIAN-ANALYSIS-OF-IMAGE-DIFFERENCES-IN-MULTIPLE-SCALES.pdf
 - id: 345
@@ -4255,7 +4255,7 @@
     \ widely used in simulation based inference. Therefore, (4) can be always obtained\
     \ through the importance sampling \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=2928307458281010860&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2928307458281010860
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407608001681
 - id: 346
@@ -4268,7 +4268,7 @@
     \ we investigate whether our artificial economy can match the empirical moments\
     \ observed in five major foreign \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=1800758482907024940&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1800758482907024940
   category: Quantitative Finance
   doi: https://link.springer.com/article/10.1007/s10614-013-9415-6
 - id: 348
@@ -4282,7 +4282,7 @@
     \ we implement a Metropolis-withinGibbs algorithm for efficient simulation-based\
     \ inference. Publicly available data on \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2859188470448051255&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2859188470448051255
   category: Quantitative Biology
   doi: https://www.tandfonline.com/doi/abs/10.1198/016214507000000923
 - id: 349
@@ -4296,7 +4296,7 @@
     \ method to infer the \u2026 In this study, we applied BOLFI [28],a recent simulation-based\
     \ inference method (also a \u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1747812375151787590&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1747812375151787590
   category: Computer Science
   doi: https://dl.acm.org/doi/abs/10.1145/3491102.3502023
 - id: 350
@@ -4310,7 +4310,7 @@
     \ to the case of inhomogeneous point processes as well as new approaches to simulation-based\
     \ inference. \u2026"
   journal: annualreviews.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10597976622237826612&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10597976622237826612
   category: Statistics
   doi: https://www.annualreviews.org/doi/abs/10.1146/annurev-statistics-060116-054055
 - id: 351
@@ -4339,7 +4339,7 @@
     \ best fitting our data. The model identified included the early divergence of\
     \ the ancestors of Pygmy hunter\u2013gatherers \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6617048751971271710&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6617048751971271710
   category: Quantitative Biology
   doi: https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1000448
 - id: 353
@@ -4382,7 +4382,7 @@
     \ of science, the field of simulation-based inference [38] is growing very rapidly\
     \ to address the associated \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=15612699499777634687&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15612699499777634687
   category: Statistics
   doi: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.106.055311
 - id: 356
@@ -4397,7 +4397,7 @@
     \ perform simulation-based inference of model parameters. The framework has the\
     \ following main advantages: (1) \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=1478024768159221596&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1478024768159221596
   category: Computer Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/00207721.2015.1090643
 - id: 357
@@ -4452,7 +4452,7 @@
     \ but has the important advantage of an invertible closed form cumulative distribution\
     \ function. The parameterization \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=18346740915892174762&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18346740915892174762
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s00362-011-0417-y
 - id: 362
@@ -4479,7 +4479,7 @@
     \ the immersive, simulation-based inference approach for which the author team\
     \ is known. Students engage with \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13545723634164584493&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13545723634164584493
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=hsb1DwAAQBAJ&oi=fnd&pg=PA1&dq=%22simulation-based%2Binference%22&ots=n0YwGiI-bn&sig=GQKcdL2o3qAX1ocoB512MeLtZXY
 - id: 364
@@ -4493,7 +4493,7 @@
     \ relationship between foreign direct investment and gross domestic product in\
     \ China for the 1982-2008 period, both in a \u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=918549871157817095&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=918549871157817095
   category: Economics
   doi: https://www.researchgate.net/profile/Ayse-Yalta-2/publication/228828821_New_Evidence_on_FDI-Led_Growth_The_Case_of_China/links/54859f730cf2437065c9e93c/New-Evidence-on-FDI-Led-Growth-The-Case-of-China.pdf
 - id: 365
@@ -4522,7 +4522,7 @@
     \ and simulation-based inference of demographic history from microsatellite sequence\
     \ alone, flanking sequence \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1244214128552618499&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1244214128552618499
   category: Quantitative Biology
   doi: https://www.nature.com/articles/s41437-022-00550-0
 - id: 368
@@ -4536,7 +4536,7 @@
     \ for integrating spatial pattern comparison into existing modelling frameworks.\
     \ To date, the literature on spatial pattern \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=3611237174481494078&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3611237174481494078
   category: Geography
   doi: https://compass.onlinelibrary.wiley.com/doi/abs/10.1111/gec3.12356
 - id: 369
@@ -4550,7 +4550,7 @@
     \ inference to explore the likelihood of generating observed genetic patterns\
     \ under alternative hypotheses. The \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=15454853611887808303&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15454853611887808303
   category: Ecology
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-2979.2008.00300.x
 - id: 370
@@ -4564,7 +4564,7 @@
     \ Bayesian inference for parameters governing stochastic kinetic models defined\
     \ as Markov jump \u2026"
   journal: mas.ncl.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=6132277325240640760&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6132277325240640760
   category: Quantitative Biology
   doi: http://www.mas.ncl.ac.uk/~nag48/publications/emMJPpaper4.pdf
 - id: 371
@@ -4595,7 +4595,7 @@
     \ \u2026 simulation-based inference methods In this section, we provide an overview\
     \ of the two main simulation-based inference \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4830613518672659224&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4830613518672659224
   arxiv_id: '2202.00625'
   arxiv_category_tag: econ.EM
   category: Economics
@@ -4610,7 +4610,7 @@
     \ state space models using sequential Monte Carlo or particle filters. Early contributions\
     \ to this include, for \u2026"
   journal: nuffield.ox.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=8756613475230180588&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8756613475230180588
   category: Statistics
   doi: http://www.nuffield.ox.ac.uk/economics/Papers/2012/doucet120601.pdf
 - id: 374
@@ -4624,7 +4624,7 @@
     \ remained mostly focused \u2026 of opportunities for improvement in the fields\
     \ of simulation-based inference and control. \u2026"
   journal: frontiersin.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17330953147864153327&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17330953147864153327
   category: Epidemiology
   doi: https://www.frontiersin.org/articles/10.3389/frai.2021.550603/full
 - id: 375
@@ -4670,7 +4670,7 @@
     \ in many such Inverse Problems presents severe challenges to existing simulation\
     \ based inference methods. \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=16419249076926265708&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16419249076926265708
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0021999115008517
 - id: 379
@@ -4713,7 +4713,7 @@
     \ surface forms with simulations (Section 4); the simulation process and our mechanism\
     \ for simulation-based inference (\u2026"
   journal: World Scientific
-  citation_backlink: https://scholar.google.com/scholar?cites=5826914888019208577&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5826914888019208577
   category: Cognitive Science
   doi: https://www.worldscientific.com/doi/abs/10.1142/9789812701886_0005
 - id: 382
@@ -4727,7 +4727,7 @@
     \ inference. The \u2026 to conduct simulation-based inference in a real, recent,\
     \ and relevant research setting. \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=3674540033092452169&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3674540033092452169
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2017.1395303
 - id: 383
@@ -4793,7 +4793,7 @@
     \ the architecture of the neural 132 network used to compute latent vectors from\
     \ trajectories, and the visualisation of \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15440169829466606936&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15440169829466606936
   category: Biophysics
   doi: 10.1101/2022.04.11.487825
 - id: 388
@@ -4807,7 +4807,7 @@
     \ (SBI) based on normalizing flows to Bayesian hierarchical models. We validate\
     \ quantitatively our proposal on a \u2026"
   journal: hal.science
-  citation_backlink: https://scholar.google.com/scholar?cites=17920849860203024649&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17920849860203024649
   category: Computer Science
   doi: https://hal.science/hal-03139916/file/main.pdf
 - id: 390
@@ -4821,7 +4821,7 @@
     \ function of the models is generally not computable, and computationally intensive\
     \ simulation-based inference \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14188637037255510214&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14188637037255510214
   category: Medicine
   doi: https://academic.oup.com/genetics/article-abstract/202/3/911/5930203
 - id: 391
@@ -4835,7 +4835,7 @@
     \ way of introducing beginners to inferential ideas. Our focus has been on conceptual\
     \ development via unifying \u2026"
   journal: assets.pubpub.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1251244629032622703&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1251244629032622703
   category: Computer Science
   doi: https://assets.pubpub.org/v6dfqlqn/85206ff9-021b-440c-9f47-38d8a4ca143d.pdf
 - id: 392
@@ -4849,7 +4849,7 @@
     \ an approach that uses Bayesian statistical modeling and simulation-based inference.\
     \ In order to detect both large and \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=7347690736346498237&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7347690736346498237
   category: Computer Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/02664763.2014.932761
 - id: 393
@@ -4863,7 +4863,7 @@
     \ of such bridges plays a key role in simulation-based inference algorithms for\
     \ MJPs. The problem is challenging due to \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=15371120385126294430&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15371120385126294430
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11222-019-09861-5
 - id: 394
@@ -4903,7 +4903,7 @@
     \ inference, and it can be viewed as a further development of SiZer technology,\
     \ originally designed for \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2153176143679546682&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2153176143679546682
   category: Computer Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/00401706.2012.648862
 - id: 398
@@ -4931,7 +4931,7 @@
     \ for an asymmetric stochastic volatility model. An acceptance-rejection Metropolis-Hastings\
     \ algorithm is developed for \u2026"
   journal: aimspress.com
-  citation_backlink: https://scholar.google.com/scholar?cites=3175992301517228567&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3175992301517228567
   category: Mathematics
   doi: http://www.aimspress.com/fileOther/PDF/QFE/QFE-02-02-325.pdf
 - id: 400
@@ -4946,7 +4946,7 @@
     \ to simulation-based inference of CMB polarization data. The first is the development\
     \ of WPH synthesis to take a single \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14580896160123629057&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14580896160123629057
   category: Astronomy
   doi: https://academic.oup.com/mnrasl/article-abstract/510/1/L1/6424934
 - id: 401
@@ -4974,7 +4974,7 @@
     \ main approaches to simulation-based inference: emulation-based approaches and\
     \ direct inference machines. We \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6723811963050182171&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6723811963050182171
   category: Statistics
   doi: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1009508
 - id: 403
@@ -4990,7 +4990,7 @@
     \ (AABC), a class of methods that extends simulation-based inference by ABC to\
     \ models in which simulating data is \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6577606754848492972&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6577606754848492972
   arxiv_id: '1301.6282'
   arxiv_category_tag: stat.CO
   category: Statistics
@@ -5020,7 +5020,7 @@
     \ data are made with the aid of forward simulations of the model, thus also referred\
     \ to as simulation-based inference [\u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3874437242164744892&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3874437242164744892
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9892800/
 - id: 406
@@ -5046,7 +5046,7 @@
     \ layer splits its input \U0001D465\u2208 \u211D\U0001D437 into two halves \U0001D465\
     1, \U0001D4652\u2026"
   journal: indico.cern.ch
-  citation_backlink: https://scholar.google.com/scholar?cites=16407442050832189960&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16407442050832189960
   category: Computer Science
   doi: https://indico.cern.ch/event/852553/contributions/4059583/attachments/2126306/3579939/INNs-CERN-October-2020.pdf
 - id: 408
@@ -5060,7 +5060,7 @@
     \ state space models using sequential Monte Carlo or particle filters. Early contributions\
     \ to this include, for \u2026"
   journal: ora.ox.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=6256093161674219464&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6256093161674219464
   category: Statistics
   doi: https://ora.ox.ac.uk/objects/uuid:c1488540-b5f4-4126-8eee-17878ddbfb28
 - id: 409
@@ -5074,7 +5074,7 @@
     \ simulation-based inference, or by an iterative procedure available in the R\
     \ package ElliptCopulas. Some \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=8849599525535572723&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8849599525535572723
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0047259X22000094
 - id: 410
@@ -5117,7 +5117,7 @@
     \ a class of asset pricing models that account for rare but severe consumption\
     \ contractions that can extend \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=18067313326813099529&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18067313326813099529
   category: Quantitative Finance
   doi: https://www.sciencedirect.com/science/article/pii/S0304407620302748
 - id: 413
@@ -5134,7 +5134,7 @@
     \ computationally-derived posterior distributions or their approximations. In\
     \ this paper, we introduce a \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1606224763166410709&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1606224763166410709
   arxiv_id: '2211.02383'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -5149,7 +5149,7 @@
     \ distinguished by how m is used. In each case a q-valued function \u03C8(\u03B8\
     ) is defined and an estimator of \u03B8 is found by \u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=18395199562890043656&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18395199562890043656
   category: Statistics
   doi: https://www.researchgate.net/profile/Paul-Fackler/publication/265449612_A_Framework_for_Indirect_Inference/links/54cba6990cf24601c08849ae/A-Framework-for-Indirect-Inference.pdf
 - id: 415
@@ -5163,7 +5163,7 @@
     \ interpretation of synthetic control (SC) methods. We develop conditional prediction\
     \ intervals in the SC framework, \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=9657010423538230705&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9657010423538230705
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/01621459.2021.1979561
 - id: 416
@@ -5195,7 +5195,7 @@
     \ methods. We show that the proposed fiducial test has correct type one error\
     \ rate asymptotically. We compare the \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=3427591226795838376&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3427591226795838376
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610926.2017.1324984
 - id: 418
@@ -5210,7 +5210,7 @@
     \ the main aim of the pipeline is the generation of training data for targeted\
     \ simulation-based inference of \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4369090397926020900&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4369090397926020900
   category: Computer Science
   doi: https://academic.oup.com/mnras/article-abstract/512/1/661/6523375
 - id: 419
@@ -5224,7 +5224,7 @@
     \ of developments in discrete choice modelling and simulation-based inference.\
     \ For many years both students and \u2026"
   journal: search.proquest.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12290102371378522031&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12290102371378522031
   category: Economics
   doi: https://search.proquest.com/openview/4478d31de8bc095591b7f175738d4a52/1?pq-origsite=gscholar&cbl=37372
 - id: 420
@@ -5238,7 +5238,7 @@
     \ model. Simulation-based methods are tractable in the context of this study for\
     \ two reasons: (1) the SV model is a \u2026"
   journal: emerald.com
-  citation_backlink: https://scholar.google.com/scholar?cites=8479003299751057505&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8479003299751057505
   category: Statistics
   doi: https://www.emerald.com/insight/content/doi/10.1108/S0731-90532019000040A008
 - id: 421
@@ -5252,7 +5252,7 @@
     \ multifractal model and estimate its parameters via both maximum likelihood and\
     \ simulation based inference approaches. \u2026"
   journal: econstor.eu
-  citation_backlink: https://scholar.google.com/scholar?cites=9220150152067147111&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9220150152067147111
   category: Quantitative Finance
   doi: https://www.econstor.eu/handle/10419/30048
 - id: 422
@@ -5279,7 +5279,7 @@
     \ the sign of the shock or on a threshold value. Threshold moving average (TMA)\
     \ models, by explicitly taking into \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12998482157660821277&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12998482157660821277
   category: Economics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610918.2015.1035447
 - id: 424
@@ -5292,7 +5292,7 @@
     \ and Econometrics. They usually lead to intractable likelihood functions, as\
     \ they involve integrals without \u2026"
   journal: academia.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=10434138472051799190&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10434138472051799190
   category: Statistics
   doi: https://www.academia.edu/download/49307773/Alternative_Simulation-Based_Estimators_20161002-8326-y9bxk1.pdf
 - id: 425
@@ -5346,7 +5346,7 @@
     \ inference method and is fully integrated with R, that is, the simulation code\
     \ and related probability \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=9620221637937348696&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9620221637937348696
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S1755436519300441
 - id: 429
@@ -5360,7 +5360,7 @@
     \ of the primordial matter power spectrum and cosmological parameters from black-box\
     \ galaxy surveys. In Section 2.1, \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=8934722355681067911&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8934722355681067911
   category: Astrophysics
   doi: https://academic.oup.com/mnras/article-abstract/490/3/4237/5583010
 - id: 430
@@ -5373,7 +5373,7 @@
     \ formulas, large-sample approximations, and probability tables, we teach statistical\
     \ concepts using simulationbased \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18096334937583767821&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18096334937583767821
   category: Computer Science
   doi: https://books.google.com/books?hl=en&lr=&id=JkQPEAAAQBAJ&oi=fnd&pg=PP1&dq=%22simulation-based%2Binference%22&ots=BrZK7Ti7pJ&sig=gHQl6vQVyZCh5febSbImxiVaNsM
 - id: 431
@@ -5386,7 +5386,7 @@
     \ simulation based inference, such as Markov chain Monte Carlo, is not feasible.\
     \ Therefore, we derive an \u2026"
   journal: gauss.stat.su.se
-  citation_backlink: https://scholar.google.com/scholar?cites=777298866234625923&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=777298866234625923
   category: Statistics
   doi: http://gauss.stat.su.se/rr/RR2003_1.pdf
 - id: 432
@@ -5401,7 +5401,7 @@
     \ and particles are used to simulate the messages between nodes, in our approach,\
     \ during the simulation based inference \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=9552368590023626984&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9552368590023626984
   category: Neuroscience
   doi: https://link.springer.com/chapter/10.1007/11867661_48
 - id: 433
@@ -5417,7 +5417,7 @@
     \ simulator g is a nonlinear function mapping a vector of parameters \u03B8 =\
     \ (\u03B81,...,\u03B8d) \u2208 Rd and a stochastic latent state z \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7785584362484287500&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7785584362484287500
   arxiv_id: '2011.13951'
   arxiv_category_tag: astro-ph.IM
   category: Astrophysics
@@ -5431,7 +5431,7 @@
     \ user supervision like other approximate methods such as variational inference\
     \ or many simulation-based inference \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=5813123603947537729&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5813123603947537729
   category: Statistics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.105.103531
 - id: 435
@@ -5444,7 +5444,7 @@
     \ made it feasible to estimate discrete choice models with several alternatives\
     \ and rich patterns of consumer taste heterogeneity\u2026"
   journal: mpra.ub.uni-muenchen.de
-  citation_backlink: https://scholar.google.com/scholar?cites=6799632434239643511&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6799632434239643511
   category: Economics
   doi: https://mpra.ub.uni-muenchen.de/id/eprint/55203
 - id: 436
@@ -5472,7 +5472,7 @@
     \ with simulators that \u2026 Parameter inference in these models requires simulation-based\
     \ inference methods such as \u2026"
   journal: ml4physicalsciences.github.io
-  citation_backlink: https://scholar.google.com/scholar?cites=8604411360344672569&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8604411360344672569
   category: Physics
   doi: https://ml4physicalsciences.github.io/2021/files/NeurIPS_ML4PS_2021_88.pdf
 - id: 438
@@ -5486,7 +5486,7 @@
     \ arbitrarily complex, allowing inference in dynamic multiple-population situations.\
     \ To do so, first one defines the model of \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=14377012286491492411&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14377012286491492411
   category: Ecology
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/mec.12741
 - id: 439
@@ -5501,7 +5501,7 @@
     \ leading indicators improve the fit of an MRS model of the US business cycle\
     \ chronology by 24 percent, such \u2026"
   journal: oecd-ilibrary.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8500048382064986220&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8500048382064986220
   category: Economics
   doi: https://www.oecd-ilibrary.org/economics/comparing-probability-forecasts-in-markov-regime-switching-business-cycle-models_jbcma-007-art4-en
 - id: 440
@@ -5516,7 +5516,7 @@
     \ biology. Biological models at the single-cell level are intrinsically stochastic\
     \ and nonlinear, creating \u2026"
   journal: royalsocietypublishing.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17363194211497642945&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17363194211497642945
   category: Quantitative Biology
   doi: https://royalsocietypublishing.org/doi/abs/10.1098/rsif.2022.0153
 - id: 441
@@ -5530,7 +5530,7 @@
     \ proposed model is applied to analyze heart disease incidence rates in the Sydney\
     \ Metropolitan Area of Australia, \u2026"
   journal: biostats.bepress.com
-  citation_backlink: https://scholar.google.com/scholar?cites=17511240603998695896&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17511240603998695896
   category: Mathematics
   doi: https://biostats.bepress.com/cgi/viewcontent.cgi?article=1067&context=harvardbiostat
 - id: 442
@@ -5561,7 +5561,7 @@
   snippet: "\u2026 We also demonstrate advantages over two alternative methods of\
     \ simulation-based inference. \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5137025473292912756&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5137025473292912756
   arxiv_id: '1004.1112'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -5575,7 +5575,7 @@
     \ or to make quantitative decisions. These models sometimes involve unknown input\
     \ parameters that need \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=4948981753169387790&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4948981753169387790
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/24725854.2017.1382751
 - id: 445
@@ -5603,7 +5603,7 @@
     \ obtain full posterior estimates for the parameters and compare these across\
     \ different retinal regions. The model \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3969956591298108135&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3969956591298108135
   category: Neuroscience
   doi: 10.1101/2021.02.24.432674
 - id: 447
@@ -5618,7 +5618,7 @@
     \ process models using Markov chain Monte Carlo (MCMC) methods, including perfect\
     \ simulation techniques. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=14061295736569169103&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14061295736569169103
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/1467-9469.00348
 - id: 448
@@ -5632,7 +5632,7 @@
     \ simulation-based inference procedure and it is very easy to implement. In Section\
     \ 3, our proposed SCIs are compared \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17150746500604626337&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17150746500604626337
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S157231271400046X
 - id: 449
@@ -5647,7 +5647,7 @@
     \ inference, as we started from statistics known to contain all information about\
     \ the parameters. In practice, one \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=14467777749557695199&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14467777749557695199
   category: Computer Science
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/1755-0998.12627
 - id: 450
@@ -5660,7 +5660,7 @@
     \ inference for spatial point processes. Two examples of applications are used\
     \ throughout the chapter for \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4302895105772903792&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4302895105772903792
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=Q7zUBwAAQBAJ&oi=fnd&pg=PR13&dq=%22simulation-based%2Binference%22&ots=_f6ZM9Ryj4&sig=WKj7iPp7uwbwhwJthEVqaX5ijYQ
 - id: 451
@@ -5674,7 +5674,7 @@
     \ \u2018sbi\u2019 (simulation based inference) \u2026 Macke Lab [4] to implement\
     \ simulation based inference for neuronal models. In their \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8152881799172104210&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8152881799172104210
   category: Neuroscience
   doi: https://ieeexplore.ieee.org/abstract/document/9441161/
 - id: 452
@@ -5688,7 +5688,7 @@
     \ can be extended to the task of Bayesian model comparison, and demonstrate its\
     \ competitive performance on \u2026"
   journal: researchgate.net
-  citation_backlink: https://scholar.google.com/scholar?cites=6585212883679706795&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6585212883679706795
   category: Neuroscience
   doi: https://www.researchgate.net/profile/Jan-Boelts-2/publication/335434321_Comparing_neural_simulations_by_neural_density_estimation/links/6022acc9458515893992ea3b/Comparing-neural-simulations-by-neural-density-estimation.pdf
 - id: 453
@@ -5702,7 +5702,7 @@
     \ use of simulation-based inference methods. We propose a full Bayesian inference\
     \ approach which can be naturally \u2026"
   journal: Citeseer
-  citation_backlink: https://scholar.google.com/scholar?cites=1116859349685389595&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1116859349685389595
   category: Economics
   doi: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=ecdb90f61803d2fc0a21cc7701fe77544b15be7e
 - id: 454
@@ -5716,7 +5716,7 @@
     \ of interest rate models known as affine term structure (ATS) models. The technique\
     \ is based on a Markov chain \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=757191850279118333&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=757191850279118333
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947304001616
 - id: 455
@@ -5729,7 +5729,7 @@
     \ labor supply and human capital investment. The model allows agents to be forward\
     \ looking. But, in contrast \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=3446829228393853758&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3446829228393853758
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407602002051
 - id: 456
@@ -5770,7 +5770,7 @@
     \ for any of the Bayesian methods listed above, due to the computational burden\
     \ imposed by simulation-based inference. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=16773312233389853708&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16773312233389853708
   category: Genetics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1365-294X.2006.02994.x
 - id: 460
@@ -5786,7 +5786,7 @@
     \ for which a specific \u2026 Our method is in so far similar to simulation-based\
     \ inference as both solely use samples from \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1831390603227994904&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1831390603227994904
   arxiv_id: '2112.10510'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -5801,7 +5801,7 @@
     \ simulated moments (Kendall et al., 1999), synthetic likelihood (Wood, 2010),\
     \ non-linear forecasting (Sugihara and \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14628411982908570466&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14628411982908570466
   arxiv_id: '1712.03058'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -5819,7 +5819,7 @@
     \ bias of estimators due to the ever-increasing data size and model complexity.\
     \ Approximate numerical methods and \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7714114392391859190&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7714114392391859190
   arxiv_id: '2010.13687'
   arxiv_category_tag: math.ST
   category: Mathematics
@@ -5834,7 +5834,7 @@
     \ software for simulation-based inference for Bayesian probability models, providing\
     \ researchers a very \u2026"
   journal: psycnet.apa.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8957879956748252043&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8957879956748252043
   category: Statistics
   doi: https://psycnet.apa.org/record/2013-44734-001
 - id: 464
@@ -5848,7 +5848,7 @@
     \ order to determine quantities such as hedging positions and the prices of other\
     \ instruments. For stochastic models \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1703026335195782469&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1703026335195782469
   category: Mathematics
   doi: https://ieeexplore.ieee.org/abstract/document/8132262/
 - id: 465
@@ -5900,7 +5900,7 @@
     \ responses to climate, and showcase the use of ancient genetic data and simulation-based\
     \ inference for \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=7712412699561212072&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7712412699561212072
   category: Ecology
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1365-294X.2009.04382.x
 - id: 469
@@ -5917,7 +5917,7 @@
     \ will be essential additions to the tool set for addressing these issues in a\
     \ principled way. We do not foresee any \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=18192713843754288911&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18192713843754288911
   arxiv_id: '2012.10260'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -5946,7 +5946,7 @@
     \ of models, test statistics for regression parameters, their p-values, linearity\
     \ of relationship, and simulation-based inference. \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=3253299524954694210&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3253299524954694210
   category: Computer Science
   doi: https://www.tandfonline.com/doi/full/10.1080/00401706.2020.1744908
 - id: 473
@@ -5960,7 +5960,7 @@
     \ Instead of web-based applets for simulation-based inference\u2026 seeking to\
     \ integrate simulation-based inference into their \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2057562688236833986&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2057562688236833986
   category: Mathematics
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1852139
 - id: 474
@@ -5975,7 +5975,7 @@
     \ approaches and direct inference machines. We employ three different emulators:\
     \ a deep neural network (\u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6915526485280798677&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6915526485280798677
   category: Bioinformatics
   doi: 10.1101/2021.10.04.462980
 - id: 475
@@ -6005,7 +6005,7 @@
     \ in the generation by computer of sequences of \u201Cpseudorandom\u201D numbers.\
     \ Following Devroye (1986), we will assume \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=7016519326531792278&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7016519326531792278
   category: Computer Science
   doi: https://link.springer.com/content/pdf/10.1007/978-3-540-75892-1_13.pdf
 - id: 477
@@ -6032,7 +6032,7 @@
     \ inference for other types of diffusion process data than discrete time observations.\
     \ Chib, Pitt and Shephard [16] presented \u2026"
   journal: projecteuclid.org
-  citation_backlink: https://scholar.google.com/scholar?cites=12998559082982944352&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12998559082982944352
   category: Mathematics
   doi: https://projecteuclid.org/journals/bernoulli/volume-20/issue-2/Simple-simulation-of-diffusion-bridges-with-application-to-likelihood-inference/10.3150/12-BEJ501
 - id: 479
@@ -6045,7 +6045,7 @@
     \ and investigates whether this pattern is valid across US industries. Using data\
     \ over the last 91 years, I confirm that \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=13329834672362945680&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13329834672362945680
   category: Quantitative Finance
   doi: https://www.sciencedirect.com/science/article/pii/S1544612320302646
 - id: 480
@@ -6058,7 +6058,7 @@
     \ the complexity problem, which arises in simulation based inference for mixtures.\
     \ The completing variable (or allocation \u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=294916556385772535&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=294916556385772535
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=739791
 - id: 481
@@ -6086,7 +6086,7 @@
     \ of simulation-based inference such as methods deploying approximate Bayesian\
     \ computation (Sunn\xE4ker et al. 2013) or \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=17450910467028349466&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17450910467028349466
   category: Genetics
   doi: https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.12489
 - id: 483
@@ -6112,7 +6112,7 @@
     \ these processes. \u2026 too fast and when V0 is sufficiently well identified,\
     \ our simulation-based inference proce- \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=14078447304320716580&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14078447304320716580
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.3982/ECTA8718
 - id: 485
@@ -6126,7 +6126,7 @@
     \ (GMM) to estimate Stochastic Volatility (SV) models. A primary attraction of\
     \ the method of moments \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=11057354418957818015&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11057354418957818015
   category: Quantitative Finance
   doi: https://link.springer.com/chapter/10.1007/978-3-540-71297-8_12
 - id: 486
@@ -6140,7 +6140,7 @@
     \ a number of scholars have started to develop and apply simulation-based inference\
     \ devices to tackle SV models. \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=1331217976051663571&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1331217976051663571
   category: Quantitative Finance
   doi: https://link.springer.com/chapter/10.1007/978-3-540-71297-8_10
 - id: 487
@@ -6154,7 +6154,7 @@
     \ inference and differentiable simulations. These range from integrating it with\
     \ FEniCS for finite elements \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=15829576722729058384&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15829576722729058384
   category: Physics
   doi: https://www.sciencedirect.com/science/article/pii/S2352711023000341
 - id: 489
@@ -6182,7 +6182,7 @@
     \ known as likelihood-free inference, which enables researchers to algorithmically\
     \ identify parameters of simulation-\u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4645018470100103099&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4645018470100103099
   category: Computer Science
   doi: https://dl.acm.org/doi/fullHtml/10.1145/3564038
 - id: 491
@@ -6209,7 +6209,7 @@
     \ inference of the SVCP model parameters, with a \u201Cburn-in\u201D of 1,000\
     \ iterations, and also fit the GWR model to the same \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=8314038722080229480&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8314038722080229480
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s10109-006-0040-y
 - id: 493
@@ -6223,7 +6223,7 @@
     \ inference, (2) use it to improve results generated with classical inference\
     \ methods such as MCMC, and (3) to \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=12030419494957555836&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12030419494957555836
   category: Astrophysics
   doi: https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.130.171403
 - id: 494
@@ -6237,7 +6237,7 @@
     \ is based primarily on simulation-based inference, where data are analyzed by\
     \ comparison to model predictions. (\u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=13495474301440972635&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13495474301440972635
   category: Computer Science
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.036011
 - id: 495
@@ -6250,7 +6250,7 @@
     \ used tools in asymptotic derivations in econometrics. Extensions of these methods\
     \ are provided for \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=10313845210114556876&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10313845210114556876
   category: Mathematics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.3982/ECTA9350
 - id: 496
@@ -6277,7 +6277,7 @@
     \ inference engine to account for differences in the interpretation of sentences\
     \ like those in the annotated \u2026"
   journal: aclanthology.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10074246062246687748&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10074246062246687748
   category: Social Science
   doi: https://aclanthology.org/C02-1156.pdf
 - id: 498
@@ -6302,7 +6302,7 @@
     \ progress in simulation-based inference have led to a host of new and powerful\
     \ statistical tools\u201D (ibid.). The book deals with \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12655532779842908951&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12655532779842908951
   category: Epidemiology
   doi: https://www.tandfonline.com/doi/pdf/10.1198/tech.2002.s98
 - id: 500
@@ -6316,7 +6316,7 @@
     \ for these complex models, and simulation-based inference through Markov chain\
     \ Monte Carlo (MCMC) has \u2026"
   journal: numdam.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6680930820925739601&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6680930820925739601
   category: Statistics
   doi: http://www.numdam.org/item/JSFS_2017__158_3_62_0/
 - id: 501
@@ -6330,7 +6330,7 @@
     \ is larger for ECA\u2019s; and in leading simulation-based inference cases with\
     \ \u03B2 = \u221E and \u03B1 2 = 1 , we need S to go to \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=11070602112082035073&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11070602112082035073
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407617300155
 - id: 502
@@ -6344,7 +6344,7 @@
     \ and Tauchen (1996) is an indirect inference estimator based on the simulated\
     \ auxiliary score evaluated at the \u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12424213504838378091&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12424213504838378091
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1626074
 - id: 503
@@ -6376,7 +6376,7 @@
     \ and heterogeneous models, we introduce Poisson Approximate Likelihood (PAL)\
     \ methods. In contrast to \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4227927378806048399&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4227927378806048399
   arxiv_id: '2205.13602'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -6390,7 +6390,7 @@
     \ approaches and to show \u2026 Throughout the work, many examples illustrate\
     \ how Bayesian simulation based inference \u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1643532933345056769&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1643532933345056769
   category: Mathematics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=739766
 - id: 506
@@ -6430,7 +6430,7 @@
     \ inference for other types of diffusion process data than discrete time observations.\
     \ Chib et al. (2006) presented a general \u2026"
   journal: JSTOR
-  citation_backlink: https://scholar.google.com/scholar?cites=4333686406062240260&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4333686406062240260
   category: Statistics
   doi: https://www.jstor.org/stable/24775342
 - id: 510
@@ -6444,7 +6444,7 @@
     \ technique in probabilistic modelling. For example, to fit a probabilistic model\
     \ \u03C0 by maximum likelihood estimation, it \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15589766408368701334&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15589766408368701334
   arxiv_id: '1811.07192'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -6459,7 +6459,7 @@
     \ are designed to reflect unequal probabilities of response and selection inherent\
     \ in complex survey sampling \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=9508207002758426099&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9508207002758426099
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/anzs.12284
 - id: 512
@@ -6509,7 +6509,7 @@
     \ parameter is not identified under the null hypothesis. We develop a testing\
     \ procedure adapted to this \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=11196086335720033253&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11196086335720033253
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1198/073500102288618829
 - id: 516
@@ -6524,7 +6524,7 @@
     \ we refer the reader to [5] for a review on the topic and the Python package\
     \ sbi for ready-to-use implementations [18]. \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15815124823811890131&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15815124823811890131
   arxiv_id: '2012.02807'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -6539,7 +6539,7 @@
     \ estimators for a general class of dynamic models with continuous laws of motion.\
     \ The consistency of \u2026"
   journal: e-archivo.uc3m.es
-  citation_backlink: https://scholar.google.com/scholar?cites=2842368791199871642&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2842368791199871642
   category: Economics
   doi: https://e-archivo.uc3m.es/handle/10016/298
 - id: 518
@@ -6554,7 +6554,7 @@
     \ disease response has become a focal point of the recent pandemic. However, it\
     \ has also highlighted a \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=10450453884613976071&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10450453884613976071
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S1755436522000093
 - id: 519
@@ -6582,7 +6582,7 @@
     \ static graphics or interactive apps. For example, there is a long history of\
     \ using apps to visualize sampling \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=5430075849501940959&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5430075849501940959
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/26939169.2021.1920866
 - id: 521
@@ -6595,7 +6595,7 @@
     \ started to use simulation based inference to tackle SV models. To discuss these\
     \ methods it will be convenient \u2026"
   journal: ora.ox.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=6513174667109016402&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6513174667109016402
   category: Quantitative Finance
   doi: https://ora.ox.ac.uk/objects/uuid:cca137f7-e304-41a6-bee3-54de46b0a965
 - id: 522
@@ -6610,7 +6610,7 @@
     \ simulation outputs, and (3) \u2026 In this study, a parameterized simulation-based\
     \ inference approach balances the benefits of \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=8163780911785871048&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8163780911785871048
   category: Engineering
   doi: https://www.sciencedirect.com/science/article/pii/S0306261920306073
 - id: 523
@@ -6639,7 +6639,7 @@
     \ This allowed large scale data generation at low computational cost and ensured\
     \ that features of one dataset could not \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6807852971590788407&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6807852971590788407
   category: Computer Science
   doi: https://iopscience.iop.org/article/10.1088/1751-8121/abfa45/meta
 - id: 526
@@ -6666,7 +6666,7 @@
     \ model is a prerequisite for simulation based inference. If the continuous time\
     \ model does not have a closed form \u2026"
   journal: hawaii.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=16382648584585201992&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16382648584585201992
   category: Economics
   doi: http://www2.hawaii.edu/~fuleky/research/DSresponse.pdf
 - id: 528
@@ -6680,7 +6680,7 @@
     \ any algebra-based introductory statistics course (eg, with or without simulation-based\
     \ inference; AP statistics, etc.) \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14084206618683612327&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14084206618683612327
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=g_L0DwAAQBAJ&oi=fnd&pg=PA1&dq=%22simulation-based%2Binference%22&ots=98J4eTCpbS&sig=MDhjs-95_7mHbI2LAs88eYcM8uM
 - id: 529
@@ -6696,7 +6696,7 @@
     \ in this study, approximate Bayesian computation (ABC) and supervised machine-learning\
     \ (SML). In all empirical \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=12465292847783364452&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12465292847783364452
   category: Evolutionary biology
   doi: 10.1101/2020.12.04.410670
 - id: 530
@@ -6722,7 +6722,7 @@
     \ [34], we carried out simulation-based inference via the original iterated filtering\
     \ (IF1), the perturbed Bayes map \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1068598867319066522&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1068598867319066522
   arxiv_id: '1802.08613'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -6748,7 +6748,7 @@
     \ Robust confidence sets by applying Indirect Inference, in the context of Autoregressive\
     \ Moving Average (\u2026"
   journal: mdpi.com
-  citation_backlink: https://scholar.google.com/scholar?cites=6619556392860525072&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6619556392860525072
   category: Statistics
   doi: https://www.mdpi.com/680612
 - id: 534
@@ -6761,7 +6761,7 @@
     \ on boosted decision trees. Since then, high energy physics (HEP) has applied\
     \ modern machine learning (ML) \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=8128538611133606535&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8128538611133606535
   category: Computer Science
   doi: https://books.google.com/books?hl=en&lr=&id=F4BfEAAAQBAJ&oi=fnd&pg=PR5&dq=%22simulation-based%2Binference%22&ots=Yh_mzUa54w&sig=gNE6gjbRE2iqUvv5wSYUKSX1cis
 - id: 535
@@ -6776,7 +6776,7 @@
     \ The generation of trajectories from a NHPP is a useful tool, particularly for\
     \ simulation based inference. There exist quite \u2026"
   journal: jstatsoft.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1636276147561965776&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1636276147561965776
   category: Statistics
   doi: https://www.jstatsoft.org/index.php/jss/article/view/v064i06/0
 - id: 536
@@ -6805,7 +6805,7 @@
     \ learning, and simulation-based inference. It is understood that highly accurate\
     \ simulations of reality remain a \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6931985883273234332&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6931985883273234332
   category: Robotics
   doi: https://ieeexplore.ieee.org/abstract/document/9398246/
 - id: 538
@@ -6819,7 +6819,7 @@
     \ by quantum field theory and nonperturbative effects and detector interactions\
     \ described by complex \u2026"
   journal: World Scientific
-  citation_backlink: https://scholar.google.com/scholar?cites=17346360696876051959&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17346360696876051959
   category: Computer Science
   doi: https://www.worldscientific.com/doi/abs/10.1142/S0217751X20410080
 - id: 539
@@ -6833,7 +6833,7 @@
     \ gives us | \u03B2 2 | , the mean of | \u03B2 2 j | across firms along with an\
     \ estimate of its sampling variation. These results are shown \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=4543520583860553958&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4543520583860553958
   category: Quantitative Finance
   doi: https://www.sciencedirect.com/science/article/pii/S0261560609001399
 - id: 540
@@ -6859,7 +6859,7 @@
     \ of linearisation can be dropped completely, though linearisation is typically\
     \ more efficient when possible. The potential \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=7453568911120042112&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7453568911120042112
   category: Geography
   doi: https://www.sciencedirect.com/science/article/pii/S0375650521002200
 - id: 543
@@ -6887,7 +6887,7 @@
     \ likelihood-free inference (\u2026 The frontier of simulation-based inference.\
     \ arXiv e-prints, art. arXiv:1911.01429, Nov 2019. \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=14385524652709102879&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14385524652709102879
   category: Statistics
   doi: http://proceedings.mlr.press/19/dalmasso20a.html
 - id: 545
@@ -6914,7 +6914,7 @@
     \ rate models driven by fractional Brownian motion (fBm) using discretely sampled\
     \ data. In the presence of a fractional \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=14070108406088197206&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14070108406088197206
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0378475413001870
 - id: 547
@@ -6929,7 +6929,7 @@
     \ the creation and use of a sampling distribution for the test statistic. However,\
     \ Hofmann et al. (2012) developed a \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=13223416161817479714&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13223416161817479714
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1837039
 - id: 548
@@ -6968,7 +6968,7 @@
     \ [SV ( p ) ] models. Due to the difficulty of evaluating the likelihood function,\
     \ this remains a challenging problem, even \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=16292913587205761521&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16292913587205761521
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407621001007
 - id: 551
@@ -6983,7 +6983,7 @@
     \ , but also for these simulation-based inference methods. This \u2026 Third,\
     \ it could be that this type of simulation-based \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=13690939344176023552&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13690939344176023552
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/10705511.2016.1247355
 - id: 552
@@ -6997,7 +6997,7 @@
     indirect inference and bootstrap bias correction\u2013are equivalent for two-stage-least-squares,\
     \ as well as k -class \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=16979118485108283667&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16979118485108283667
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0165176514001189
 - id: 553
@@ -7012,7 +7012,7 @@
     \ that can be easily exploited within simulation-based inference procedures, such\
     \ as Monte Carlo and bootstrap tests. \u2026"
   journal: emerald.com
-  citation_backlink: https://scholar.google.com/scholar?cites=791576026196468282&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=791576026196468282
   category: Mathematics
   doi: https://www.emerald.com/insight/content/doi/10.1016/S0731-9053(05)20010-5/full/html
 - id: 554
@@ -7027,7 +7027,7 @@
     \ two widely used simulation-based techniques for estimating structural models\
     \ that have intractable likelihood \u2026"
   journal: Citeseer
-  citation_backlink: https://scholar.google.com/scholar?cites=6181320096168734601&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6181320096168734601
   category: Statistics
   doi: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=e336640e8fb1c0831743a50b29196032ec50112e
 - id: 555
@@ -7068,7 +7068,7 @@
     \ If simulation-based inference is applied again, it might then \u2026 or returned\
     \ to simulation-based inference to further identify \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=8051244049133684331&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8051244049133684331
   category: Quantitative Biology
   doi: https://www.sciencedirect.com/science/article/pii/S1084952123000290
 - id: 558
@@ -7082,7 +7082,7 @@
     \ inference methods. In Section 3, we validate the measurements we derive from\
     \ our models and in \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=10752615220777441649&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10752615220777441649
   category: Astronomy
   doi: https://academic.oup.com/mnras/article-abstract/518/1/353/6823712
 - id: 559
@@ -7096,7 +7096,7 @@
     \ and Gilles Louppe, discuss another emergent surprise in their article \u201C\
     The frontier of simulation-based inference\u201D (\u2026"
   journal: National Acad Sciences
-  citation_backlink: https://scholar.google.com/scholar?cites=17454054759384261013&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17454054759384261013
   category: Computer Science
   doi: https://www.pnas.org/doi/abs/10.1073/pnas.2020596117
 - id: 560
@@ -7111,7 +7111,7 @@
     \ packages (collections of R code functions) specifically designed to support\
     \ novices to learn simulation-based inference \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=8451642188025500534&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8451642188025500534
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10986065.2021.1922856
 - id: 561
@@ -7136,7 +7136,7 @@
     \ (Bayesian) inference in complex hierarchical models, and efficient simulation\
     \ of GMRFs is therefore one of the central \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9952551302840634691&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9952551302840634691
   category: Mathematics
   doi: https://books.google.com/books?hl=en&lr=&id=TLBYs-faw-0C&oi=fnd&pg=PP1&dq=%22simulation-based%2Binference%22&ots=RO1NzNRtnW&sig=O4rd8YDz5t1qIeR3mxbLZwMpTTY
 - id: 563
@@ -7151,7 +7151,7 @@
     \ calibrated to data and provide estimates of uncertainty. Two main components\
     \ of model-calibration methods \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3622843412715023129&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3622843412715023129
   category: Epidemiology
   doi: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007893
 - id: 564
@@ -7166,7 +7166,7 @@
     \ (BLIS) assessment for students in an introductory statistics course, at the\
     \ postsecondary level, that includes, to \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=12814345964732310471&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12814345964732310471
   category: Education
   doi: https://www.iase-web.org/ojs/SERJ/article/view/164
 - id: 565
@@ -7180,7 +7180,7 @@
     \ started to use simulation-based inference to tackle SV models. To discuss these\
     \ methods it will be convenient to \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=1899108729891726799&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1899108729891726799
   category: Mathematics
   doi: https://link.springer.com/chapter/10.1057/9780230280830_31
 - id: 566
@@ -7193,7 +7193,7 @@
     \ to wait perhaps for decades for sufficient advancements in computer technology\
     \ is the simulation-based inference for \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=3043388788992877439&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3043388788992877439
   category: Economics
   doi: https://link.springer.com/chapter/10.1057/9780230280816_3
 - id: 567
@@ -7207,7 +7207,7 @@
     \ powerful for enhancing the power of simulation-based inference for small changes\
     \ in the parameter \u03B8 . When \u2026"
   journal: National Acad Sciences
-  citation_backlink: https://scholar.google.com/scholar?cites=13862948520861870522&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13862948520861870522
   category: Computer Science
   doi: https://www.pnas.org/doi/abs/10.1073/pnas.1915980117
 - id: 568
@@ -7222,7 +7222,7 @@
     \ Iterated Filtering [21]. We compared the models from three different aspects,\
     \ parameter estimation, simulation, and \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8480450777389140971&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8480450777389140971
   category: Medicine
   doi: https://ieeexplore.ieee.org/abstract/document/9671543/
 - id: 569
@@ -7237,7 +7237,7 @@
     \ for analysis of generative models, such as simulation-based inference for empirical\
     \ test statistics as we will see in a case \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=12474158776087933751&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12474158776087933751
   category: Statistics
   doi: https://link.springer.com/chapter/10.1007/978-3-030-57521-2_23
 - id: 570
@@ -7251,7 +7251,7 @@
     \ likelihood-free inference) as they can reduce the number of simulated events\
     \ needed by orders of magnitude [18\u2026"
   journal: gbaydin.github.io
-  citation_backlink: https://scholar.google.com/scholar?cites=16672897415360215987&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16672897415360215987
   category: Physics
   doi: https://gbaydin.github.io/assets/pdf/baydin-2020-differentiable.pdf
 - id: 571
@@ -7265,7 +7265,7 @@
     \ Bayesian models, where the inference problem is transformed into a density-ration\
     \ estimation problem, which is \u2026"
   journal: ncbi.nlm.nih.gov
-  citation_backlink: https://scholar.google.com/scholar?cites=4060573888453923324&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4060573888453923324
   category: Computer Science
   doi: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7041362/
 - id: 572
@@ -7279,7 +7279,7 @@
     \ information between Autonomous Systems (AS). It is a dynamic, distributed, path-vector\
     \ protocol that \u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6709662490313275487&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6709662490313275487
   category: Computer Science
   doi: https://dl.acm.org/doi/abs/10.1145/3341617.3326145
 - id: 573
@@ -7293,7 +7293,7 @@
     \ problems \u2026 As these modern simulation-based inference methods show promising\
     \ results with ABM \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=11727194811316960749&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11727194811316960749
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S1364815222002146
 - id: 575
@@ -7307,7 +7307,7 @@
     \ (SBI) methods have been developed that allow parameter inference to be performed\
     \ on arbitrary black-box \u2026"
   journal: proceedings.neurips.cc
-  citation_backlink: https://scholar.google.com/scholar?cites=6171069613024886899&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6171069613024886899
   category: Statistics
   doi: https://proceedings.neurips.cc/paper_files/paper/2022/hash/db0eac6747e3631eb91095cd76065611-Abstract-Conference.html
 - id: 576
@@ -7323,7 +7323,7 @@
     \ [2] and stochastic variational inference (SVI) [3] \u2013 can be used for simulation-based\
     \ inference under an exchangeable \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8603664056820260428&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8603664056820260428
   arxiv_id: '1807.00420'
   arxiv_category_tag: stat.CO
   category: Statistics
@@ -7339,7 +7339,7 @@
     \ parameters of mechanistically motivated parametric models when evaluating likelihoods\
     \ is \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=16121802686828083714&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16121802686828083714
   category: Quantitative Biology
   doi: https://www.sciencedirect.com/science/article/pii/S0040580914000744
 - id: 578
@@ -7354,7 +7354,7 @@
     \ progress in the field of likelihood-free inference (LFI), also known as simulation-based\
     \ inference, which has \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4437013765746610654&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4437013765746610654
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.3847/1538-3881/abf42e/meta
 - id: 579
@@ -7368,7 +7368,7 @@
     \ a dynamic panel data model with fixed effects is inconsistent under fixed time\
     \ series sample size and large cross \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=3453188696865029461&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3453188696865029461
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407609002772
 - id: 580
@@ -7382,7 +7382,7 @@
     \ with substantially more time-efficient computation, which is illustrated with\
     \ a voxel-based meta-analysis of verbal fluency \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17434411282486869969&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17434411282486869969
   category: Neuroscience
   doi: https://www.sciencedirect.com/science/article/pii/S1053811909000743
 - id: 582
@@ -7395,7 +7395,7 @@
     \ this is the first text to tackle difficult issues of simulation and simulation-based\
     \ inference for such processes, \u2026"
   journal: academia.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=14567790211706228956&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14567790211706228956
   category: Statistics
   doi: https://www.academia.edu/download/43593619/Nonlinear_time_series_nonparametric_and_20160310-29217-19xmvp7.pdf
 - id: 583
@@ -7422,7 +7422,7 @@
     \ inference method, can be used for parameter inference in these models. We hope\
     \ this will inspire further \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4867433329802707697&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4867433329802707697
   category: Computer Science
   doi: https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1010591
 - id: 585
@@ -7451,7 +7451,7 @@
     \ the dynamics of economic and financial data, and a great deal of effort has\
     \ been expended searching for \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12722499708000852453&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12722499708000852453
   category: Mathematics
   doi: https://www.tandfonline.com/doi/abs/10.1198/073500102288618397
 - id: 587
@@ -7466,7 +7466,7 @@
     \ the limits of our understanding. Examples include, but are not limited to, flexible\
     \ Bayesian approaches (eg BUGS, stan\u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=13590501547093925845&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13590501547093925845
   category: Mathematics
   doi: https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.14030
 - id: 588
@@ -7480,7 +7480,7 @@
     \ for the class of singular shape graphs. In Section 5 we present negative implications\
     \ of unrestrained use of context \u2026"
   journal: drops.dagstuhl.de
-  citation_backlink: https://scholar.google.com/scholar?cites=10681233420095515910&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10681233420095515910
   category: Computer Science
   doi: https://drops.dagstuhl.de/opus/volltexte/2022/15888/
 - id: 589
@@ -7494,7 +7494,7 @@
     \ diffusion processes. We examine two types of estimators based on the Euler scheme,\
     \ one applied to the original \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=8064177514644031050&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8064177514644031050
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407605001375
 - id: 590
@@ -7508,7 +7508,7 @@
     \ biology. Using simulations to calculate statistics or to explore parameter space\
     \ is a common means for analysing \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18116952117198932511&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18116952117198932511
   category: Computer Science
   doi: https://academic.oup.com/bioinformatics/article-abstract/27/6/874/235103
 - id: 591
@@ -7522,7 +7522,7 @@
     \ and testability in econometrics. We consider inference in non\u2010parametric\
     \ models and weakly identified structural \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=4136747418398871400&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4136747418398871400
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/1540-5982.t01-3-00001
 - id: 592
@@ -7535,7 +7535,7 @@
     \ statisticians but its flexibility makes it ideal for problems in political science\
     \ where we are interested in \u2026"
   journal: JSTOR
-  citation_backlink: https://scholar.google.com/scholar?cites=6003372266412780484&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6003372266412780484
   category: Social Science
   doi: https://www.jstor.org/stable/43288447
 - id: 593
@@ -7549,7 +7549,7 @@
     \ for simulation-based inference to provide an intuitive introduction to inferential\
     \ concepts. We also agreed to \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=14428901919102474244&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14428901919102474244
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1730734
 - id: 594
@@ -7564,7 +7564,7 @@
     \ multitype Bellman\u2013Harris branching processes when the data consist of cell\
     \ counts collected on several colonies \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=785137931019125060&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=785137931019125060
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0378375806000723
 - id: 595
@@ -7578,7 +7578,7 @@
     \ so instead we must rely on simulation based methods. Unfortunately, drawing\
     \ exact realisations, results in \u2026"
   journal: degruyter.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13973631115863483686&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13973631115863483686
   category: Mathematics
   doi: https://www.degruyter.com/document/doi/10.1515/sagmb-2014-0071/html?lang=de
 - id: 596
@@ -7593,7 +7593,7 @@
     \ of Gaussian process approximations to non-linear stochastic individual-based\
     \ models of epidemics. We \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=4243947637374015837&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4243947637374015837
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0025556417303644
 - id: 597
@@ -7606,7 +7606,7 @@
     \ estimation method for Dynamic Stochastic General Equilibrium [DSGE] models by\
     \ testing for \u2026"
   journal: fass.nus.edu.sg
-  citation_backlink: https://scholar.google.com/scholar?cites=776299917586992439&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=776299917586992439
   category: Economics
   doi: https://fass.nus.edu.sg/ecs/wp-content/uploads/sites/4/2020/06/18-05-16.pdf
 - id: 598
@@ -7620,7 +7620,7 @@
     \ inference methods. These methods allow us to estimate the deep parameters of\
     \ the theoretical models \u2026"
   journal: Citeseer
-  citation_backlink: https://scholar.google.com/scholar?cites=14244219486973274734&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14244219486973274734
   category: Economics
   doi: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=6cbc75bba5be832e4bf25c405d5c34daf54925d9
 - id: 599
@@ -7634,7 +7634,7 @@
     \ produce self-relaxing programs where possible, because then we believe that\
     \ a variety of simulation-based inference \u2026"
   journal: mit.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=16583234479377869685&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16583234479377869685
   category: Computer Science
   doi: http://web.mit.edu/vkm/www/FreerManRoy-NIPSMC-2010.pdf
 - id: 601
@@ -7649,7 +7649,7 @@
     \ Likelihood-Ratio statistic to test non-nested models. To date simulation has\
     \ been used to estimate the Kullback-\u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12974728808217139984&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12974728808217139984
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=394341
 - id: 602
@@ -7675,7 +7675,7 @@
     \ supplementary information. \u2026 Next-level calibration with simulation-based\
     \ inference Although we have reduced the \u2026"
   journal: openreview.net
-  citation_backlink: https://scholar.google.com/scholar?cites=16293310063483508690&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16293310063483508690
   category: Economics
   doi: https://openreview.net/forum?id=jycOgqMX0xA
 - id: 604
@@ -7690,7 +7690,7 @@
     \ based on the rigorous approach of non-parametric simulation-based inference\
     \ using 10,000 repetitions. We tested \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=9127842449501684472&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9127842449501684472
   category: Social Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/17439760.2019.1615108
 - id: 605
@@ -7718,7 +7718,7 @@
     \ of the national academy of sciences of \u2026 \u201CAverting a crisis in simulation-based\
     \ inference\u201D. In: Arxiv:2110.06581. Hooker, G. \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=5323224577768390792&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5323224577768390792
   category: Statistics
   doi: https://proceedings.mlr.press/51/dellaporta22a.html
 - id: 608
@@ -7735,7 +7735,7 @@
     \ to straightforwardly handle both missing and zero (censored) observations by\
     \ appealing to data augmentation (Tanner \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16668300376474579452&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16668300376474579452
   arxiv_id: '2105.03269'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -7750,7 +7750,7 @@
     \ 1972) and Bayesian methods (Bayes 1763), and thus these are first introduced.\
     \ Likelihood-based inference \u2026"
   journal: repository.up.ac.za
-  citation_backlink: https://scholar.google.com/scholar?cites=9393021721273262898&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9393021721273262898
   category: Quantitative Biology
   doi: https://repository.up.ac.za/handle/2263/29290
 - id: 610
@@ -7765,7 +7765,7 @@
     \ multivariable modeling, data \u2026 Simulation-based inference is another topic\
     \ missing from the statistics education literature \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=4675441200919250896&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4675441200919250896
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2019.1687369
 - id: 611
@@ -7779,7 +7779,7 @@
     \ Simulation-based inference and Theory-based (asymptotic) inference. An emphasis\
     \ on guided discovery, the use \u2026"
   journal: icots.info
-  citation_backlink: https://scholar.google.com/scholar?cites=1259017007397283768&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1259017007397283768
   category: Education
   doi: https://icots.info/9/proceedings/pdfs/ICOTS9_1F1_SWANSON.pdf
 - id: 612
@@ -7793,7 +7793,7 @@
     \ spiking and adapting modules simultaneously combining the segregation approach\
     \ and simulation-basedinference (\u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10494802893427520886&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10494802893427520886
   category: Neuroscience
   doi: https://ieeexplore.ieee.org/abstract/document/9441222/
 - id: 613
@@ -7807,7 +7807,7 @@
     \ methods such as maximum likelihood estimation (MLE), we have had to resort to\
     \ simulation-based inference techniques\u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15926594168521956120&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15926594168521956120
   category: Computer Science
   doi: https://dl.acm.org/doi/abs/10.1145/3544548.3581439
 - id: 614
@@ -7820,7 +7820,7 @@
     \ progress in simulation-based inference have led to a host of new and powerful\
     \ statistical tools\u201D (ibid.). The book deals with \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12091582656332344252&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12091582656332344252
   category: Environmental Science
   doi: https://www.tandfonline.com/doi/pdf/10.1198/tech.2002.s97
 - id: 615
@@ -7833,7 +7833,7 @@
     \ tasks; thus, it is likely that this modified experiment would present an ideal\
     \ scenario for simulation-based inference \u2026"
   journal: dspace.mit.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=15892786242035270669&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15892786242035270669
   category: Physics
   doi: https://dspace.mit.edu/handle/1721.1/77012
 - id: 616
@@ -7848,7 +7848,7 @@
     \ disease models. \u2026 that in simulation-based inference, the simulator itself\
     \ defines the statistical model [49]. \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=16736485743021963512&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16736485743021963512
   category: Neuroscience
   doi: https://link.springer.com/chapter/10.1007/978-3-030-93080-6_5
 - id: 617
@@ -7875,7 +7875,7 @@
     \ for the statistical treatment of new DLV models. Simulated likelihood techniques\
     \ based on importance sampling \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1576894516443282682&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1576894516443282682
   category: Quantitative Finance
   doi: https://academic.oup.com/jfec/article-abstract/1/3/297/836068
 - id: 620
@@ -7889,7 +7889,7 @@
     \ offers considerable 25 conceptual advantages over more traditional methods for\
     \ inverse parameter estimation, can \u2026"
   journal: Citeseer
-  citation_backlink: https://scholar.google.com/scholar?cites=4741382632537829191&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4741382632537829191
   category: Mathematical
   doi: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=b524e87fb56fb60bd8a4c04cb28a20e7313667b9
 - id: 621
@@ -7917,7 +7917,7 @@
     \ courses, such as study design, data production and management, and simulation-based\
     \ inference, are included in \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=17290327966723121655&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17290327966723121655
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1713936
 - id: 623
@@ -7943,7 +7943,7 @@
     \ models. As such, it is derived from the works of many leading authors in this\
     \ expanding fi eld. The book \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=3806635021965898101&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3806635021965898101
   category: Quantitative Finance
   doi: https://www.tandfonline.com/doi/pdf/10.1198/tech.2004.s749
 - id: 625
@@ -7970,7 +7970,7 @@
     \ of new control and perception methods. This task typically involves the estimation\
     \ of simu-lation parameter \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=12840410202137009091&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12840410202137009091
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9812293/
 - id: 627
@@ -8011,7 +8011,7 @@
     \ estimation of stochastic Wiener systems. It is well known that the likelihood\
     \ function of the observed outputs for \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=18405917011793506365&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18405917011793506365
   category: Mathematics
   doi: https://ieeexplore.ieee.org/abstract/document/7798727/
 - id: 631
@@ -8025,7 +8025,7 @@
     \ the likelihood of stochastic differential equations. This technique is based\
     \ on a result of Dacunha\u2010Castelle and \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12036698140441818239&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12036698140441818239
   category: Mathematics
   doi: https://academic.oup.com/ectj/article-abstract/5/1/91/5073316
 - id: 632
@@ -8040,7 +8040,7 @@
     \ amplification using two alternative simulation-based inference approaches. Sequential\
     \ Monte Carlo approximate \u2026"
   journal: elifesciences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=2481111762060767224&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2481111762060767224
   category: Neuroscience
   doi: https://elifesciences.org/articles/56265
 - id: 633
@@ -8054,7 +8054,7 @@
     \ provide likelihood estimates of model parameters could be used to compete a\
     \ suite of alternative hypotheses. Such \u2026"
   journal: National Acad Sciences
-  citation_backlink: https://scholar.google.com/scholar?cites=694975333004976492&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=694975333004976492
   category: Medicine
   doi: https://www.pnas.org/doi/abs/10.1073/pnas.0602960103
 - id: 635
@@ -8068,7 +8068,7 @@
     \ data Tobit model (censored regression) with random effects is eval-ueted with\
     \ Monte Carlo experiments. Bias \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=11777607687559814632&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11777607687559814632
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=LW9E-fhmk8QC&oi=fnd&pg=PA349&dq=%22simulation-based%2Binference%22&ots=OWVmSz82cZ&sig=-QOyHtdzso5MU7WfWS3Iudk74Ro
 - id: 636
@@ -8082,7 +8082,7 @@
     \ likelihood inference (or the misnomer, likelihood-free inference), SBI sequesters\
     \ the model to the simulator only [2]. For a \u2026"
   journal: osti.gov
-  citation_backlink: https://scholar.google.com/scholar?cites=4802353364916094071&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4802353364916094071
   category: Physics
   doi: https://www.osti.gov/biblio/1886020
 - id: 637
@@ -8121,7 +8121,7 @@
     \ and the size and power of a test on the impacts with both the analytical formula\
     \ and the simulation-based inference. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=16368272562934846240&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16368272562934846240
   category: Computer Science
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/gean.12318
 - id: 640
@@ -8138,7 +8138,7 @@
     \ to be modified substantially, and the lack of independence between cases might\
     \ make a simulation-based inference \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9360212987984638246&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9360212987984638246
   category: Epidemiology
   doi: 10.1101/677021
 - id: 641
@@ -8152,7 +8152,7 @@
     \ normal pace of society at multiple levels\u2014from daily activities in personal\
     \ and professional lives to the \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=3358173722064456739&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3358173722064456739
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S2472630321000236
 - id: 642
@@ -8177,7 +8177,7 @@
     \ mimeo . \u2026 Persistence robust simulation-based inference for autoregressive\
     \ moving average processes. mimeo . \u2026"
   journal: blocnotesdeleco.banque-france.fr
-  citation_backlink: https://scholar.google.com/scholar?cites=845586708568513769&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=845586708568513769
   category: Economics
   doi: https://blocnotesdeleco.banque-france.fr/sites/default/files/media/2017/04/13/lynda_khalaf.pdf
 - id: 644
@@ -8204,7 +8204,7 @@
     \ and inference. They have been used successfully for multisensor fusion and situation\
     \ assessment. It is well \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3315015652698694523&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3315015652698694523
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/1021199/
 - id: 646
@@ -8218,7 +8218,7 @@
     \ adjustments. Multiple adjustments require \U0001D443 values with a resolution\
     \ that makes resampling or simulation based inference \u2026"
   journal: hindawi.com
-  citation_backlink: https://scholar.google.com/scholar?cites=10652958101609230003&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10652958101609230003
   category: Quantitative Biology
   doi: https://www.hindawi.com/journals/cmmm/2013/413783/
 - id: 647
@@ -8232,7 +8232,7 @@
     \ It begins by presenting the statistical framework and the maintained assumptions.\
     \ It \u2026 Simulation-based inference \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=741637407687457936&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=741637407687457936
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947311003070
 - id: 649
@@ -8247,7 +8247,7 @@
     \ for simulation-based inference [\u2026 Our simulation-based inference solution\
     \ to motor control is fast, only requiring a minimal \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10244245412568604072&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10244245412568604072
   category: Neuroscience
   doi: https://iopscience.iop.org/article/10.1088/1741-2552/ac9646/meta
 - id: 650
@@ -8261,7 +8261,7 @@
     \ Markov-chain Monte Carlo (MCMC) methods. Such methods have proven to be particularly\
     \ well suited for \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=7501524304121897759&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7501524304121897759
   category: Quantitative Finance
   doi: https://www.tandfonline.com/doi/abs/10.1198/073500101316970403
 - id: 651
@@ -8288,7 +8288,7 @@
     \ wherever needed. For example, percentiles from the marginal posterior distributions,\
     \ while not available in closed \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=1737445599418764855&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1737445599418764855
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947313000042
 - id: 653
@@ -8302,7 +8302,7 @@
     \ data on the development of cell clones composed of two (or more) distinct types\
     \ of cells. The proposed model \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=10476326677946316751&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10476326677946316751
   category: Mathematics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.0006-341X.2005.031210.x
 - id: 654
@@ -8317,7 +8317,7 @@
     \ simulation-based inference, which might have a long lasting impact on science\
     \ (Cranmer et al., 2020). \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=5921293867486617216&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5921293867486617216
   category: Engineering
   doi: https://www.sciencedirect.com/science/article/pii/S0009250921008368
 - id: 656
@@ -8360,7 +8360,7 @@
     \ to prove instrumental in generating constrained training examples for simulation-based\
     \ inference of dark matter \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16509080770043304545&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16509080770043304545
   arxiv_id: '2211.04365'
   arxiv_category_tag: astro-ph.IM
   category: Astrophysics
@@ -8375,7 +8375,7 @@
     \ means that experts and novices meet together weekly to discuss the practice\
     \ of teaching simulation-based inference\u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=13526937676364698897&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13526937676364698897
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1787115
 - id: 660
@@ -8390,7 +8390,7 @@
     \ alongside dynamic changes in plate tectonics and temperature over the Cenozoic\
     \ using a simulation-based inference \u2026"
   journal: dora.lib4ri.ch
-  citation_backlink: https://scholar.google.com/scholar?cites=3039551049754749569&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3039551049754749569
   category: Quantitative Biology
   doi: https://www.dora.lib4ri.ch/wsl/islandora/object/wsl%3A31811/datastream/PDF/Skeels-2022-Temperature-dependent_evolutionary_speed_shapes_the-%28published_version%29.pdf
 - id: 661
@@ -8404,7 +8404,7 @@
     \ to methods that use simulation-based inference, such as Approximate Bayesian\
     \ Computing (ABC) or synthetic \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=3856184813070049011&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3856184813070049011
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/ele.13728
 - id: 662
@@ -8434,7 +8434,7 @@
     \ as optimal compressors in simulation-based inference density estimation. We\
     \ include supplementary descriptions \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=422840710276332585&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=422840710276332585
   arxiv_id: '2207.05202'
   arxiv_category_tag: astro-ph.CO
   category: Astrophysics
@@ -8451,7 +8451,7 @@
     \ relations, few studies focus on building neurocognitive models that describe\
     \ both human EEG and behavioral \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=14822270014333858587&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14822270014333858587
   category: Neuroscience
   doi: https://link.springer.com/article/10.1007/s42113-023-00167-4
 - id: 665
@@ -8466,7 +8466,7 @@
     \ is assumed to arise as a set of observations from a spatial nonhomogeneous Poisson\
     \ process. The spatial point \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=484722615938567257&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=484722615938567257
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0378375807000821
 - id: 667
@@ -8492,7 +8492,7 @@
     \ inference, is probably the best way to model integer time series. However, there\
     \ has been increasing \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=15475645859194536354&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15475645859194536354
   category: Mathematics
   doi: https://link.springer.com/content/pdf/10.1007/978-3-319-07028-5.pdf
 - id: 669
@@ -8521,7 +8521,7 @@
     \ methods based on Bayesian statistics for performing simulation-based inference;\
     \ often used when the likelihood \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4733319875956851789&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4733319875956851789
   category: Genetics
   doi: https://academic.oup.com/gbe/article-abstract/14/7/evac088/6604401
 - id: 671
@@ -8536,7 +8536,7 @@
     \ and thus the problem naturally lends itself to simulation-based inference. In\
     \ this work, we present an approximate \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=14469950867282338163&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14469950867282338163
   category: Physics
   doi: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.93.063311
 - id: 672
@@ -8566,7 +8566,7 @@
     \ is simulation-based inference using probabilistic deep learning [13\u201322].\
     \ Technologies such as normalizing flows enable \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=10483097627857667564&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10483097627857667564
   category: Physics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.107.084046
 - id: 674
@@ -8594,7 +8594,7 @@
     \ teaching in Introductory Statistics Class to analyze the effectiveness of this\
     \ teaching strategy. We give a brief \u2026"
   journal: search.proquest.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18149178638119740586&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18149178638119740586
   category: Education
   doi: https://search.proquest.com/openview/34e560a9ebd6d88d2dd1a172a3bc788e/1?pq-origsite=gscholar&cbl=18750
 - id: 676
@@ -8609,7 +8609,7 @@
     \ been recently investigated by [5] while the application of simulation-based\
     \ inference procedures is usually required for \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=4449082811631327504&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4449082811631327504
   category: Statistics
   doi: https://link.springer.com/chapter/10.1007/978-88-470-2871-5_4
 - id: 677
@@ -8622,7 +8622,7 @@
     \ of the posterior (using mixture distributions) and then uses importance sampling\
     \ for simulation based inference. \u2026"
   journal: deepblue.lib.umich.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=215529725412748736&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=215529725412748736
   category: Statistics
   doi: https://deepblue.lib.umich.edu/bitstream/handle/2027.42/116262/CRAN%20Task%20View_%20Bayesian%20Inference.pdf?sequence=1
 - id: 678
@@ -8637,7 +8637,7 @@
     \ for empirical validation of ABMs, taking advantage of the availability of powerful\
     \ personal computers and \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=510219684928809735&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=510219684928809735
   category: Economics
   doi: https://link.springer.com/chapter/10.1007/978-981-13-8319-9_10
 - id: 679
@@ -8662,7 +8662,7 @@
     \ , unlike the case of simulation-based inference\u2014this difference \u2026\
     \ Eg in simulation-based inference, the exact estimator would \u2026"
   journal: academiccommons.columbia.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=7107350263905890042&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7107350263905890042
   category: Statistics
   doi: https://academiccommons.columbia.edu/doi/10.7916/D83X8JV4
 - id: 681
@@ -8675,7 +8675,7 @@
     \ strands of reasoning\u2014one establishing the reliability of the experiment\
     \ and the other establishing the empirical \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=6901714210328609033&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6901714210328609033
   category: Computer Science
   doi: https://link.springer.com/article/10.1007/s11229-009-9612-y
 - id: 682
@@ -8690,7 +8690,7 @@
     \ simulation of communities undergoing local neutral dynamics with environmentally\
     \ filtered immigration from a \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=3622990176404053214&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3622990176404053214
   category: Ecology
   doi: https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.12918
 - id: 684
@@ -8704,7 +8704,7 @@
     \ across scientific \u2026 In simulation-based inference, experimental data arising\
     \ from a physical system typically \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13870381265686715875&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13870381265686715875
   category: Computer Science
   doi: https://www.nature.com/articles/s41598-022-10966-7
 - id: 685
@@ -8718,7 +8718,7 @@
     \ the field and covers all relevant topics both from a statistical and an econometrical\
     \ point of view. There are many \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=7906812793426254751&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7906812793426254751
   category: Quantitative Finance
   doi: https://books.google.com/books?hl=en&lr=&id=u1TmA-lm7loC&oi=fnd&pg=PR2&dq=%22simulation-based%2Binference%22&ots=Fg56TaBJUc&sig=d8X2aONwIq2Q-xb5fZH-LLSGBX0
 - id: 686
@@ -8745,7 +8745,7 @@
     \ of selection. This study's findings reinforced others that have identified post-admixture\
     \ selection pressure to retain \u2026"
   journal: royalsocietypublishing.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14551260748102428094&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14551260748102428094
   category: Genetics
   doi: https://royalsocietypublishing.org/doi/abs/10.1098/rstb.2020.0410
 - id: 688
@@ -8758,7 +8758,7 @@
     \ Inference and Its Applications with R provides a clear exposition of the methods\
     \ of statistical inference for \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=17994855944642779855&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17994855944642779855
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=XPgDTUkus_IC&oi=fnd&pg=PP1&dq=%22simulation-based%2Binference%22&ots=DsAKmIDw4q&sig=DWFDY8JWbSdJAngJKq55UnhahuY
 - id: 689
@@ -8773,7 +8773,7 @@
     \ sampling techniques to simulate a sufficient number of cases and compute posteriors\
     \ from them. Researchers have \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=12895254820341547374&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12895254820341547374
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S0888613X03000173
 - id: 690
@@ -8788,7 +8788,7 @@
     \ pressures and densities. While there is no direct way to explore their interior\
     \ structure, X-rays emitted from these \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10746700695326616239&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10746700695326616239
   category: Astronomy
   doi: https://iopscience.iop.org/article/10.1088/1475-7516/2023/02/016/meta
 - id: 691
@@ -8802,7 +8802,7 @@
     \ data. The procedure is valid for large dimensions and sample sizes. The case\
     \ of small sample sizes has not been \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12390721478330671650&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12390721478330671650
   category: Statistics
   doi: https://journals.sagepub.com/doi/pdf/10.1177/0962280220970228
 - id: 692
@@ -8817,7 +8817,7 @@
     \ can only perform well if the underlying simulation method preserves the structural\
     \ properties of the SDE. While the \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=15147755997357025160&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15147755997357025160
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11222-019-09909-6
 - id: 693
@@ -8832,7 +8832,7 @@
     \ inference to fit \u2026 SNPE is a Bayesian simulation-based inference algorithm\
     \ that allows parameter estimation \u2026"
   journal: elifesciences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16474599872544323574&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16474599872544323574
   category: Neuroscience
   doi: https://elifesciences.org/articles/54997
 - id: 694
@@ -8847,7 +8847,7 @@
     \ course offerings are still influenced by a legacy of mathematically centric\
     \ thinking. Due to this legacy, Bayesian \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=12632973020271964203&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12632973020271964203
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1841591
 - id: 695
@@ -8874,7 +8874,7 @@
     \ of our simulation-based inference approach. In particular if we let X denote\
     \ the set of modes of the prior predictive \u2026"
   journal: projecteuclid.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1641859515038182481&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1641859515038182481
   category: Statistics
   doi: https://projecteuclid.org/journals/bayesian-analysis/volume-17/issue-2/On-Bayesian-inference-for-the-Extended-Plackett-Luce-model/10.1214/21-BA1258
 - id: 697
@@ -8888,7 +8888,7 @@
     \ almost all branches of science. However, this problem can prove notably difficult\
     \ when processes and model \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4562044798774401391&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4562044798774401391
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9298920/
 - id: 698
@@ -8902,7 +8902,7 @@
     \ easy enough to program a Metropolis algorithm that converged well and yielded\
     \ simulation-based inference for all the \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=2931675429706219719&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2931675429706219719
   category: Statistics
   doi: https://link.springer.com/chapter/10.1007/978-1-4419-6944-6_11
 - id: 699
@@ -8929,7 +8929,7 @@
     \ networks. However, these algorithms are vulnerable to attack from coordinated\
     \ campaigns spreading \u2026"
   journal: ora.ox.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=4076503708726408468&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4076503708726408468
   category: Computer Science
   doi: https://ora.ox.ac.uk/objects/uuid:d1b07465-cf5b-4cee-8c02-8ab1ff900623/files/s8623j018t
 - id: 701
@@ -8943,7 +8943,7 @@
     \ for stochastic kinetic models. Whilst it is possible to work directly with the\
     \ resulting Markov jump process (MJP)\u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1394950699310032483&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1394950699310032483
   category: Statistics
   doi: https://iopscience.iop.org/article/10.1088/0266-5611/30/11/114005/meta
 - id: 702
@@ -8975,7 +8975,7 @@
     \ towards a hybrid modelling approach. Such a combination of data-based and knowledge-based\
     \ \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=13564574582521444031&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13564574582521444031
   category: Computer Science
   doi: https://link.springer.com/chapter/10.1007/978-3-030-44584-3_43
 - id: 704
@@ -8989,7 +8989,7 @@
     \ European origins of the LN \u2026 embrace their potential complexity and use\
     \ simulation based inference procedures. We have \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14257165463492868799&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14257165463492868799
   category: Quantitative Biology
   doi: https://academic.oup.com/mbe/article-abstract/30/2/285/1018802
 - id: 705
@@ -9003,7 +9003,7 @@
     \ finance representation of the yield curve. However, the possibility that DTSM\
     \ estimates may be distorted by \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=5594966467766750566&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5594966467766750566
   category: Quantitative Finance
   doi: https://www.tandfonline.com/doi/abs/10.1080/07350015.2012.693855
 - id: 706
@@ -9016,7 +9016,7 @@
     \ parameter dependent. This paper addresses this problem from an identification-robust\
     \ perspective. Confidence \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=413842211277188245&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=413842211277188245
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407614001419
 - id: 707
@@ -9048,7 +9048,7 @@
     \ proposed, using approximate Bayesian computation (ABC). ABC avoids evaluation\
     \ of an intractable likelihood \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=13722617486884861690&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13722617486884861690
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/10618600.2018.1552154
 - id: 709
@@ -9080,7 +9080,7 @@
     \ (Pool, 2016) to identify significant QTLs and calculate their confidence intervals\
     \ and effect sizes. The custom \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=8185111504096033519&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8185111504096033519
   category: Genetics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1002/ece3.8228
 - id: 711
@@ -9095,7 +9095,7 @@
     \ innovations, improved a lot: Simulation based inference, focus on multivariate\
     \ modeling, and reproducible analysis are \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2932956410116028642&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2932956410116028642
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1752859
 - id: 712
@@ -9122,7 +9122,7 @@
     \ models when standard likelihood estimation methods are computationally infeasible.\
     \ For instance, \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=2411563373041594031&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2411563373041594031
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S0167947323000737
 - id: 714
@@ -9137,7 +9137,7 @@
     \ imputations\u201Dl= 1, \u2026 , L of the completed data y l com along with the\
     \ corresponding draws of the parameters (\u03B8 l , \u03C6 l ). The \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=6487950056033280488&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6487950056033280488
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.0006-341X.2005.031010.x
 - id: 715
@@ -9152,7 +9152,7 @@
     \ as we are rather interested in establishing our simulation-based inference method\
     \ as being robust, accurate, and \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=11206282991104223774&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11206282991104223774
   category: Astronomy
   doi: https://academic.oup.com/mnras/article-abstract/506/2/1623/6297283
 - id: 716
@@ -9192,7 +9192,7 @@
     \ for deformable object manipulation as simulation-based inference over a distributional\
     \ representation of the state. \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9520798284436671732&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9520798284436671732
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9730061/
 - id: 719
@@ -9206,7 +9206,7 @@
     \ biology during the last decade (Fu and Li 1997; Pritchard et al. 1999; Fagundes\
     \ et al. 2007). In these \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=16803933202778982709&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16803933202778982709
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11222-009-9116-0
 - id: 720
@@ -9222,7 +9222,7 @@
     \ is a ubiquitous inverse problem in science and engineering. In this paper, we\
     \ suggest an inexpensive and \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1981919482379335901&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1981919482379335901
   arxiv_id: '2011.02838'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -9238,7 +9238,7 @@
     \ infeasible, so we use simulation-based inference, and match summary statistics\
     \ between the simulated and \u2026"
   journal: ncbi.nlm.nih.gov
-  citation_backlink: https://scholar.google.com/scholar?cites=4372051519674921902&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4372051519674921902
   category: Quantitative Biology
   doi: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5320679/
 - id: 722
@@ -9267,7 +9267,7 @@
     \ statistics (eg, that residuals are Normally distributed, have constant variance,\
     \ and cases are independent). \u2026"
   journal: peerj.com
-  citation_backlink: https://scholar.google.com/scholar?cites=11352331607205260991&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11352331607205260991
   category: Quantitative Biology
   doi: https://peerj.com/articles/9089/
 - id: 724
@@ -9280,7 +9280,7 @@
     \ using only simulated samples x is called simulation-based inference (SBI). Existing\
     \ approaches for SBI include \u2026"
   journal: tobias-lib.ub.uni-tuebingen.de
-  citation_backlink: https://scholar.google.com/scholar?cites=17392716181672139633&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17392716181672139633
   category: Computer Science
   doi: https://tobias-lib.ub.uni-tuebingen.de/xmlui/handle/10900/135001
 - id: 725
@@ -9325,7 +9325,7 @@
     \ technique. Since this is a Bayesian approach, the prior distribution must be\
     \ stated. To obtain posteriors that are \u2026"
   journal: JSTOR
-  citation_backlink: https://scholar.google.com/scholar?cites=11196376910966721133&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11196376910966721133
   category: Economics
   doi: https://www.jstor.org/stable/41240306
 - id: 729
@@ -9339,7 +9339,7 @@
     \ of \u2026 For this reason, simulation-based inference (and hence, in \u2026\
     \ n \u22121/2 , which are common in simulation-based \u2026"
   journal: annualreviews.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7888604339573372421&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7888604339573372421
   category: Statistics
   doi: https://www.annualreviews.org/doi/abs/10.1146/annurev-statistics-060116-054045
 - id: 730
@@ -9398,7 +9398,7 @@
     \ the brain, we employed a simulation-based inference that retrieves model parameters\
     \ with the same age-declining FC \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4652349872914450002&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4652349872914450002
   category: Neuroscience
   doi: 10.1101/2022.02.17.480902
 - id: 734
@@ -9414,7 +9414,7 @@
     \ estimation bias when handling the ever-increasing data size and model complexity.\
     \ For example, approximate \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9761862128574653272&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9761862128574653272
   arxiv_id: '2204.07907'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -9430,7 +9430,7 @@
     \ solving these nonlinear constraints for m ( i ) . (3) Once the optimal centers\
     \ are found, they could be plugged into the \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=15277850199401405511&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15277850199401405511
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0045782522005102
 - id: 736
@@ -9443,7 +9443,7 @@
     \ related to the intellectual property of the simulation program, where the computer\
     \ code is not publicly available, but the \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=2853136336014498352&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2853136336014498352
   category: Statistics
   doi: https://link.springer.com/article/10.1140/epjc/s10052-022-10581-w
 - id: 737
@@ -9457,7 +9457,7 @@
     \ is the construction of series representations of L\xE9vy processes and their\
     \ integrals. Barndorff-Nielsen & Shephard (\u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=10025816323321897618&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10025816323321897618
   category: Statistics
   doi: https://academic.oup.com/biomet/article-abstract/94/3/627/263755
 - id: 738
@@ -9473,7 +9473,7 @@
     \ mainly based on iterated filtering and maximum likelihood, whereas rbi is typically\
     \ used for Bayesian \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4648587632742137193&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4648587632742137193
   arxiv_id: '2101.08492'
   arxiv_category_tag: stat.CO
   category: Statistics
@@ -9491,7 +9491,7 @@
     \ inference. \u2026 fast and computationally inexpensive way to do this compared\
     \ to simulation-based inference. \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17413457653456404269&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17413457653456404269
   category: Medicine
   doi: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0241949
 - id: 740
@@ -9505,7 +9505,7 @@
     \ inference, SNPE (14), to estimate the set of circuit parameters (the posterior\
     \ distribution) consistent with data \u2026"
   journal: National Acad Sciences
-  citation_backlink: https://scholar.google.com/scholar?cites=8883336140812542436&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8883336140812542436
   category: Electrical Engineering and Systems Science
   doi: https://www.pnas.org/doi/abs/10.1073/pnas.2207632119
 - id: 741
@@ -9520,7 +9520,7 @@
     \ optimization routines, for example, the function optim() in R, so there is no\
     \ need for simulation-based inference \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=17717859307141441540&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17717859307141441540
   category: Quantitative Biology
   doi: https://journals.sagepub.com/doi/pdf/10.1191/1471082X05st098oa
 - id: 742
@@ -9534,7 +9534,7 @@
     \ possible, and by way of simulation-based inference, parameter estimates can\
     \ be obtained. The SIENA software \u2026"
   journal: econtent.hogrefe.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1306081734604686489&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1306081734604686489
   category: Social Science
   doi: https://econtent.hogrefe.com/doi/abs/10.1027/1614-2241.2.1.48
 - id: 743
@@ -9564,7 +9564,7 @@
     \ to the basics of econometrics. This companion focuses on the foundations of\
     \ the field and at the same \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13301062323451612771&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13301062323451612771
   category: Economics
   doi: https://books.google.com/books?hl=en&lr=&id=xs55E7FsMHMC&oi=fnd&pg=PR3&dq=%22simulation-based%2Binference%22&ots=gpgmU4XrDu&sig=a5T4DOeMyJVcnN7_aRLYFWn0F_E
 - id: 745
@@ -9580,7 +9580,7 @@
     \ inference across different paradigms and derive new simulation-based inference\
     \ approaches. We conclude by \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15579616023267106642&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15579616023267106642
   arxiv_id: '2012.04464'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -9611,7 +9611,7 @@
     \ fluctuations of their parameters. However, human cognition is inherently dynamic,\
     \ regardless of the \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10015730611961081314&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10015730611961081314
   arxiv_id: '2211.13165'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -9643,7 +9643,7 @@
     \ errors. Information in higher order cumulants allows identification of the parameters\
     \ without \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=1222613781435721019&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1222613781435721019
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/07350015.2014.955175
 - id: 750
@@ -9656,7 +9656,7 @@
     \ me to the field of simulation-based inference and, more generally, to the world\
     \ of research. I am grateful for his \u2026"
   journal: matheo.uliege.be
-  citation_backlink: https://scholar.google.com/scholar?cites=14814476942598578825&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14814476942598578825
   category: Mathematics
   doi: https://matheo.uliege.be/handle/2268.2/12993
 - id: 751
@@ -9687,7 +9687,7 @@
     \ usually requires a high number of forward model calls in order to arrive at\
     \ stationary state of the chain and \u2026"
   journal: search.proquest.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2631207674861390592&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2631207674861390592
   category: Physics
   doi: https://search.proquest.com/openview/0f0a5baeab2d3d9cdee80ca728c8c8fe/1?pq-origsite=gscholar&cbl=2069209
 - id: 753
@@ -9702,7 +9702,7 @@
     \ this matrix has to be computed for each generated sample (at least several thousands,\
     \ generally). The \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=7341488199973278026&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7341488199973278026
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S1352231020304659
 - id: 754
@@ -9716,7 +9716,7 @@
     \ on the cartpole test data the results clearly show an advantage of the strong\
     \ inductive bias our simulation-based inference \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17333297562731454083&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17333297562731454083
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9981687/
 - id: 756
@@ -9730,7 +9730,7 @@
     \ analysis. However, until estimation of AB models become a common practice, they\
     \ will not get to the \u2026"
   journal: laboratoriorevelli.it
-  citation_backlink: https://scholar.google.com/scholar?cites=6605949726716663975&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6605949726716663975
   category: Economics
   doi: http://www.laboratoriorevelli.it/_pdf/wp130.pdf
 - id: 757
@@ -9757,7 +9757,7 @@
     \ 9,10 biasing with restraints, 11,12 Bayesian ensemble refinement, 13 or other\
     \ simulation-based inference \u2026"
   journal: pubs.rsc.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6520780751516003442&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6520780751516003442
   category: Chemistry
   doi: https://pubs.rsc.org/en/content/articlehtml/2021/sc/d1sc01895g
 - id: 759
@@ -9771,7 +9771,7 @@
     \ processes has been \u2026 tractable and, in particular, is open to simulation-based\
     \ inference. Recall that a point process X on \u2026"
   journal: cambridge.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17301597301126437470&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17301597301126437470
   category: Statistics
   doi: https://www.cambridge.org/core/journals/advances-in-applied-probability/article/generalised-shot-noise-cox-processes/7709C4FFC998D2B33AF6E022D25E15F9
 - id: 760
@@ -9786,7 +9786,7 @@
     \ between the real-word and hypothetical aspects of simulation-based inference\
     \ (see p. 18). They found \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=7133423761736549630&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7133423761736549630
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10986065.2021.1922858
 - id: 761
@@ -9814,7 +9814,7 @@
     \ masses with 3D convolutional neural networks, arXiv:2009.03340 [MNRAS (to be\
     \ published)], https://doi.org/10.1093/\u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=17533622806674341711&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17533622806674341711
   category: Astrophysics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.103.023009
 - id: 763
@@ -9829,7 +9829,7 @@
     \ stochastic processes, it should be possible in many cases to adopt methods of\
     \ simulation-based inference [13]\u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17054133609337377161&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17054133609337377161
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0378437106004298
 - id: 764
@@ -9844,7 +9844,7 @@
     \ not feel confident to \u2026 as variability, sampling distributions, and simulation-based\
     \ inference, all of which benefit from the \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2989117324269099445&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2989117324269099445
   category: Education
   doi: https://journals.sagepub.com/doi/pdf/10.1177/0022487117697918
 - id: 765
@@ -9858,7 +9858,7 @@
     \ asymptotic theory for non-stationary processes, and certain nonlinear models,\
     \ to mention just a few. \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=1174452097378577255&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1174452097378577255
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9574.2004.00266.x
 - id: 766
@@ -9873,7 +9873,7 @@
     \ inference method which is non-simulative and is different from samplings that\
     \ are commonly used in circuit simulations. In \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15286884843242721501&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15286884843242721501
   category: Electrical Engineering and Systems Science
   doi: https://ieeexplore.ieee.org/abstract/document/1383338/
 - id: 767
@@ -9887,7 +9887,7 @@
     \ inference (SBI) or traditional, non-simulation-based inference (nonSBI), without\
     \ a clear textbook or \u2026"
   journal: search.proquest.com
-  citation_backlink: https://scholar.google.com/scholar?cites=5421928946373935592&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5421928946373935592
   category: Education
   doi: https://search.proquest.com/openview/166fce84d1f6e259259ab5d4c50fe768/1?pq-origsite=gscholar&cbl=18750&diss=y
 - id: 768
@@ -9914,7 +9914,7 @@
     \ about the model except the parameter value that generated the observed sample,\
     \ and use of neural nets for parameter \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=8457340933012922540&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8457340933012922540
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S2452306216300326
 - id: 770
@@ -9929,7 +9929,7 @@
     \ will be further exploited to obtain simulated testing procedures. In what follows,\
     \ we will focus on the particular case \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=15701412108417058737&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15701412108417058737
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407608002182
 - id: 771
@@ -9955,7 +9955,7 @@
     \ inference methods, shows that the presence of some unobservable and persistent\
     \ factor is needed to \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=4114480116660117169&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4114480116660117169
   category: Quantitative Finance
   doi: https://www.sciencedirect.com/science/article/pii/S0304393212001341
 - id: 773
@@ -9969,7 +9969,7 @@
     based inference also attracts the interest of \u2026 Researchers began to use\
     \ simulation\u2013based inference in the 1990s. Both \u2026"
   journal: etd.uum.edu.my
-  citation_backlink: https://scholar.google.com/scholar?cites=17555444973838975921&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17555444973838975921
   category: Quantitative Finance
   doi: https://etd.uum.edu.my/6895/2/s93750_01.pdf
 - id: 774
@@ -9982,7 +9982,7 @@
     \ are inaccessible or a closed-form mathematical expression of the likelihood\
     \ function cannot be defined. For \u2026"
   journal: mdpi.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14918833155016412936&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14918833155016412936
   category: Statistics
   doi: https://www.mdpi.com/1023460
 - id: 775
@@ -9996,7 +9996,7 @@
     \ can improve upon the vanilla ABC algorithm by considering the selection of parameters\
     \ for the simulations, the \u2026"
   journal: taylorfrancis.com
-  citation_backlink: https://scholar.google.com/scholar?cites=7416167749122439003&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7416167749122439003
   category: Epidemiology
   doi: https://www.taylorfrancis.com/chapters/edit/10.1201/9781315222912-10/approximate-bayesian-computation-methods-epidemic-models-peter-neal
 - id: 776
@@ -10011,7 +10011,7 @@
     \ MCMC methods. Such methods have proved to be particularly well suited for solving\
     \ the high-dimensional \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=10991490162014623323&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10991490162014623323
   category: Mathematics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610918.2016.1217013
 - id: 777
@@ -10026,7 +10026,7 @@
     \ point processes. In: MB Hansen and J. M\xF8ller (eds): Spatial Statistics and\
     \ Computational Methods, Springer, New \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=73694907464443692&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=73694907464443692
   category: Computer Science
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1002/bimj.200390018
 - id: 778
@@ -10054,7 +10054,7 @@
     \ commonly lack a tractable likelihood function, rendering traditional likelihood-based\
     \ statistical inference \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=343532100661494688&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=343532100661494688
   category: Computer Science
   doi: https://proceedings.mlr.press/51/dyer22a.html
 - id: 780
@@ -10067,7 +10067,7 @@
     \ in which simulation-based inference is carried out within a MCMC framework (Marjoram\
     \ et al. 2003). Proposals were \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=14064204748967278949&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14064204748967278949
   category: Genetics
   doi: https://academic.oup.com/mbe/article-abstract/32/9/2483/1031127
 - id: 781
@@ -10094,7 +10094,7 @@
     \ combination of a scaled Jeffreys' divergence and a reversed Jensen-Shannon divergence.\
     \ Upper and \u2026"
   journal: dml.cz
-  citation_backlink: https://scholar.google.com/scholar?cites=1728712362134290995&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1728712362134290995
   category: Statistics
   doi: https://dml.cz/dmlcz/149345
 - id: 783
@@ -10107,7 +10107,7 @@
     \ force within genetics and bioinformatics. Novel computational algorithms have\
     \ enabled use of probability \u2026"
   journal: ingentaconnect.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1929548557016707910&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1929548557016707910
   category: Quantitative Biology
   doi: https://www.ingentaconnect.com/content/ben/cbio/2006/00000001/00000002/art00004
 - id: 784
@@ -10121,7 +10121,7 @@
     \ inference on the unknown parameters of a general class of discrete-time stochastic\
     \ volatility (SV) models\u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2680784376666818594&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2680784376666818594
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1763783
 - id: 786
@@ -10135,7 +10135,7 @@
     \ inference. Sampling is related to filtering. A sampling distribution collects\
     \ summary values from these samples, and \u2026"
   journal: escholarship.org
-  citation_backlink: https://scholar.google.com/scholar?cites=17136101298652143588&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17136101298652143588
   category: Computer Science
   doi: https://escholarship.org/uc/item/0mg8m7g6
 - id: 787
@@ -10150,7 +10150,7 @@
     \ approach detailed below) is an interesting alternative to the estimation of\
     \ more complex models involving stable \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=2049161056120254234&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2049161056120254234
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/00949655.2014.934244
 - id: 788
@@ -10164,7 +10164,7 @@
     \ into simulation-based inference pipelines from time series allele frequency\
     \ data. This is particularly useful in \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2241232100841690053&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2241232100841690053
   category: Statistics
   doi: https://academic.oup.com/bioinformatics/article-abstract/39/1/btad017/6984715
 - id: 789
@@ -10180,7 +10180,7 @@
     \ calibrating the parameters of complex, stochastic models, required when the\
     \ likelihood of the observed data is \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1461596828534937406&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1461596828534937406
   arxiv_id: '2112.11971'
   arxiv_category_tag: stat.CO
   category: Statistics
@@ -10197,7 +10197,7 @@
     \ for simulator models with intractable likelihood. Recently, many works trained\
     \ neural networks to \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11680365573457584274&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11680365573457584274
   arxiv_id: '2205.15784'
   arxiv_category_tag: stat.CO
   category: Statistics
@@ -10212,7 +10212,7 @@
     \ machine-learning methods are growing field of research, where inference approaches\
     \ for both Bayesian and \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1967145026706419629&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1967145026706419629
   arxiv_id: '2203.13079'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -10227,7 +10227,7 @@
     \ environment-disease relations, identify significant environmental predictors\
     \ of malaria transmission and provide \u2026"
   journal: geospatialhealth.net
-  citation_backlink: https://scholar.google.com/scholar?cites=8014663481462402301&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8014663481462402301
   category: Statistics
   doi: https://www.geospatialhealth.net/index.php/gh/article/view/287
 - id: 793
@@ -10241,7 +10241,7 @@
     \ but does make use of computer simulations to illustrate concepts. The CANVAS\
     \ learning management system is used \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=976962230758740886&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=976962230758740886
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/26939169.2021.1995545
 - id: 794
@@ -10254,7 +10254,7 @@
     \ simulation-based inference. The SIENA software instantiates simulation-based\
     \ method of moments estimation of the \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=14749262080851543080&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14749262080851543080
   category: Social Science
   doi: https://www.sciencedirect.com/science/article/pii/S0378873308000270
 - id: 795
@@ -10282,7 +10282,7 @@
     \ of the ability of simulation-based inference procedures to yield good results\
     \ for relatively small values of the simulation \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=8458597869724764509&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8458597869724764509
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610918.2018.1485941
 - id: 797
@@ -10297,7 +10297,7 @@
     \ for large systems. However, the computational efficiency of QDC, the adopted\
     \ method for simulating queues, \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1722066037973839651&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1722066037973839651
   category: Economics
   doi: https://academic.oup.com/jrsssc/article-abstract/70/3/770/7033981
 - id: 798
@@ -10310,7 +10310,7 @@
     \ a financial instrument at a specified price or better. A market's limit order\
     \ book collects all its outstanding limit orders, \u2026"
   journal: search.proquest.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9377344643516314299&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9377344643516314299
   category: Quantitative Finance
   doi: https://search.proquest.com/openview/9e1f8889a4a6255471b814fd7efb3a7f/1?pq-origsite=gscholar&cbl=18750
 - id: 799
@@ -10325,7 +10325,7 @@
     \ the ratio of gene transfers within the population considered, and those from\
     \ external origins, and the results \u2026"
   journal: JSTOR
-  citation_backlink: https://scholar.google.com/scholar?cites=3834192604417407849&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3834192604417407849
   category: Quantitative Biology
   doi: https://www.jstor.org/stable/26666151
 - id: 800
@@ -10340,7 +10340,7 @@
     \ inference methods in econometrics, specifically bootstrap methods. This year,\
     \ I wish to focus on another issue \u2026"
   journal: cirano.qc.ca
-  citation_backlink: https://scholar.google.com/scholar?cites=7500425978680991770&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7500425978680991770
   category: Economics
   doi: https://www2.cirano.qc.ca/~dufourj/Web_Site/Dufour_2003_CEAPresAddress_Slides_W.pdf
 - id: 801
@@ -10354,7 +10354,7 @@
     \ inference approach [66\u201368] (see Supplemental Material [47]) to determine\
     \ values of the unknown parameters \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=15735525512547648552&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15735525512547648552
   category: Physics
   doi: https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.129.030603
 - id: 802
@@ -10368,7 +10368,7 @@
     \ \u2026 are a type of simulation-based inference approaches which are \u2026\
     \ However, simulation-based inference does not explicitly \u2026"
   journal: frontiersin.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6114369345699661382&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6114369345699661382
   category: Robotics
   doi: https://www.frontiersin.org/articles/10.3389/frobt.2022.799893/full?utm_source=ad&utm_medium=tw&utm_campaign=ba_sci-hz_frobt&twclid=23lplcfud7ivfxxdxrni07c6gu
 - id: 803
@@ -10383,7 +10383,7 @@
     \ nonlinear panel data models, which may be static or dynamic, through the introduction\
     \ of Simulation-Based inference. \u2026"
   journal: eprints.lse.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=2086278081727821001&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2086278081727821001
   category: Economics
   doi: https://eprints.lse.ac.uk/102843/
 - id: 804
@@ -10397,7 +10397,7 @@
     \ inference, this thesis presents some concrete applications to relevant research\
     \ questions in cognitive \u2026"
   journal: archiv.ub.uni-heidelberg.de
-  citation_backlink: https://scholar.google.com/scholar?cites=17573880382355649726&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17573880382355649726
   category: Computer Science
   doi: https://archiv.ub.uni-heidelberg.de/volltextserver/30807/
 - id: 805
@@ -10424,7 +10424,7 @@
     \ and asset allocation. Here we propose a novel way of estimating models of time-varying\
     \ covariances \u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9521030571057190305&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9521030571057190305
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1293629
 - id: 807
@@ -10452,7 +10452,7 @@
     \ been held every second year since 1981. Over the years, the workshops have increased\
     \ in size and in \u2026"
   journal: ias-iss.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10391304222047457255&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10391304222047457255
   category: Mathematics
   doi: https://ias-iss.org/ojs/IAS/article/view/1755
 - id: 809
@@ -10467,7 +10467,7 @@
     \ methods to classify the \u2026 We use simulation-based inference methods that\
     \ allow us to perform model selection in a \u2026"
   journal: journals.uchicago.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=13827404081361794580&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13827404081361794580
   category: Quantitative Biology
   doi: https://www.journals.uchicago.edu/doi/abs/10.1086/701125
 - id: 810
@@ -10481,7 +10481,7 @@
     \ times in a simulation-based inference process is computationally prohibitive\
     \ for large-size datasets. However, it is easy \u2026"
   journal: SIAM
-  citation_backlink: https://scholar.google.com/scholar?cites=4952303674754058078&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4952303674754058078
   category: Statistics
   doi: https://epubs.siam.org/doi/abs/10.1137/130932831
 - id: 811
@@ -10496,7 +10496,7 @@
     \ species is essential for making predictions and management decisions. In many\
     \ cases, estimating unknown \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=10298127168666815470&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10298127168666815470
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947315000122
 - id: 812
@@ -10511,7 +10511,7 @@
     \ between theories and affords quantitative fits to behavioral/brain data. Pragmatically,\
     \ however, the space of \u2026"
   journal: elifesciences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9084099492482334542&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9084099492482334542
   category: Cognitive Science
   doi: https://elifesciences.org/articles/65074
 - id: 813
@@ -10541,7 +10541,7 @@
     \ Inference for Bulk Segregation Analysis Mapping). QTL names are according to\
     \ Table 1. Discontinuities in the \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4351263535332282598&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4351263535332282598
   category: Genetics
   doi: https://academic.oup.com/genetics/article-abstract/204/3/1307/6066361
 - id: 815
@@ -10556,7 +10556,7 @@
     \ various fields of science (Cranmer et al., 2020). In parameter identification,\
     \ optimization-based approaches are \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=12911551973728503263&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12911551973728503263
   category: Robotics
   doi: https://link.springer.com/article/10.1007/s10514-023-10094-9
 - id: 816
@@ -10570,7 +10570,7 @@
     \ and display of data from multi-state models. Transitions between states are\
     \ described by rates (intensities)\u2026"
   journal: jstatsoft.org
-  citation_backlink: https://scholar.google.com/scholar?cites=5745935723337673539&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5745935723337673539
   category: Statistics
   doi: https://www.jstatsoft.org/index.php/jss/article/view/v038i06
 - id: 817
@@ -10599,7 +10599,7 @@
     \ inference that can deliver correct parameter estimation with appropriate choices\
     \ for its design. It has the \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13365818552386995143&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13365818552386995143
   category: Astrophysics
   doi: https://academic.oup.com/mnras/article-abstract/469/3/2791/3737672
 - id: 819
@@ -10612,7 +10612,7 @@
     \ whilst also avoiding the somewhat complex and non-trivial modelling issues surrounding\
     \ simulation-based inference \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=5829879034340504013&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5829879034340504013
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s10687-007-0054-y
 - id: 820
@@ -10627,7 +10627,7 @@
     \ models are simulated moments (Kendall and others, 1999), nonlinear forecasting\
     \ (Sugihara and May, 1990), \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12387115182681490207&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12387115182681490207
   category: Epidemiology
   doi: https://academic.oup.com/biostatistics/article-abstract/21/3/400/5108499
 - id: 821
@@ -10641,7 +10641,7 @@
     \ used approach to obtain control policies that can bridge the gap between simulation\
     \ and reality. However, \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=8041811915821830931&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8041811915821830931
   category: Computer Science
   doi: https://proceedings.mlr.press/64/muratore22a.html
 - id: 822
@@ -10656,7 +10656,7 @@
     \ and automating simulation-based inference approaches. However, in its current\
     \ form, SNPE will be a powerful tool for \u2026"
   journal: elifesciences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8457905584217673829&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8457905584217673829
   category: Computer Science
   doi: https://elifesciences.org/articles/56261
 - id: 823
@@ -10669,7 +10669,7 @@
     \ Random probability distribution functions are constructed via normalization\
     \ of random measures \u2026"
   journal: projecteuclid.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10726110807374692213&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10726110807374692213
   category: Mathematics
   doi: https://projecteuclid.org/journals/annals-of-statistics/volume-32/issue-6/Normalized-random-measures-driven-by-increasing-additive-processes/10.1214/009053604000000625
 - id: 825
@@ -10687,7 +10687,7 @@
     \ robotics, computer vision, control theory, physics-based modelling, reinforcement\
     \ learning and simulation-based inference\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11926499705041242973&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11926499705041242973
   arxiv_id: '2012.03806'
   arxiv_category_tag: cs.RO
   category: Computer Science
@@ -10703,7 +10703,7 @@
     \ the preferred method used to estimate term structure models. We study the finite-sample\
     \ properties of two standard \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2702736759798639640&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2702736759798639640
   category: Economics
   doi: https://academic.oup.com/jfec/article-abstract/6/1/108/798047
 - id: 827
@@ -10718,7 +10718,7 @@
     \ and consistent picture of the quantity and general properties of dark matter,\
     \ its fundamental nature remains \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=14544989964371242862&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14544989964371242862
   category: Astrophysics
   doi: https://www.sciencedirect.com/science/article/pii/S2214404822000349
 - id: 828
@@ -10732,7 +10732,7 @@
     \ efficient method of moments and indirect inference, when applied to estimating\
     \ stationary ARMA models. Issues \u2026"
   journal: degruyter.com
-  citation_backlink: https://scholar.google.com/scholar?cites=5911046124659216301&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5911046124659216301
   category: Statistics
   doi: https://www.degruyter.com/document/doi/10.2202/1558-3708.1074/html
 - id: 829
@@ -10746,7 +10746,7 @@
     \ continuous time models used in finance. Since the exact likelihood can be constructed\
     \ only in special \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=3752560926913759590&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3752560926913759590
   category: Quantitative Finance
   doi: https://link.springer.com/chapter/10.1007/978-3-540-71297-8_22
 - id: 830
@@ -10760,7 +10760,7 @@
     \ Inference and the Efficient Method of Moments, depends on the choice of the\
     \ auxiliary model, which is some-\u2026"
   journal: papers.ssrn.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12810553133636149565&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12810553133636149565
   category: Statistics
   doi: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1986419
 - id: 831
@@ -10773,7 +10773,7 @@
     \ that mating takes place at random can be convenient from a modelling and computational\
     \ point of view \u2026"
   journal: orbit.dtu.dk
-  citation_backlink: https://scholar.google.com/scholar?cites=3311208413478638796&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3311208413478638796
   category: Genetics
   doi: https://orbit.dtu.dk/files/61051172/PopStruct_OUP_Gilles_Guillot3.pdf
 - id: 832
@@ -10788,7 +10788,7 @@
     \ wrote the code and scripts for all methodological steps, performed the analyses,\
     \ and visualized the results. MvK \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=18217517799571834425&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18217517799571834425
   category: Cognitive Science
   doi: https://www.nature.com/articles/s41562-021-01282-7
 - id: 833
@@ -10803,7 +10803,7 @@
     \ cannot compete with linear methods from the computational cost viewpoint, especially\
     \ when simulation-based inference \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=13829656041560712194&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13829656041560712194
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947313004003
 - id: 834
@@ -10817,7 +10817,7 @@
     \ However, for these models, the problem of maximum likelihood identification\
     \ is very challenging due to the \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=13036177934291598948&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13036177934291598948
   category: Mathematics
   doi: https://www.sciencedirect.com/science/article/pii/S2405896317324655
 - id: 835
@@ -10832,7 +10832,7 @@
     \ estimation, have been successfully applied in parameter inference problems for\
     \ simulation-based inference [11]. Another \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=3470792680527665748&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3470792680527665748
   category: Quantitative Biology
   doi: https://link.springer.com/article/10.1007/s10928-021-09787-4
 - id: 836
@@ -10846,7 +10846,7 @@
     \ inference. The algorithms utilize the hierarchical structure of the models and\
     \ rigorously exploit the sparsity of \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=9756825669379945791&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9756825669379945791
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11222-012-9366-0
 - id: 837
@@ -10860,7 +10860,7 @@
     \ coefficients and a simulation-based inference for the threshold coefficient.\
     \ Finally, we apply the general results to \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=6372973588312917585&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6372973588312917585
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/07350015.2017.1319373
 - id: 838
@@ -10874,7 +10874,7 @@
     \ provides one promising platform for joint estimation of demographic history\
     \ and selection, progress on this front has \u2026"
   journal: journals.plos.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3145056667338594677&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3145056667338594677
   category: Genetics
   doi: https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3001669
 - id: 839
@@ -10899,7 +10899,7 @@
     \ our approach\u2014 is an exact simulation-based inference procedure originally\
     \ proposed by Dwass (1957) and Barnard (1963). It \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=6204153651600483939&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6204153651600483939
   category: Quantitative Finance
   doi: https://link.springer.com/chapter/10.1007/0-387-25118-9_9
 - id: 841
@@ -10925,7 +10925,7 @@
     \ as to how to perform (approximate) Bayesian inference for such models, without\
     \ using simulation based inference, \u2026"
   journal: journals.sagepub.com
-  citation_backlink: https://scholar.google.com/scholar?cites=13443009551345218380&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13443009551345218380
   category: Statistics
   doi: https://journals.sagepub.com/doi/pdf/10.1177/1471082X13494527
 - id: 843
@@ -10938,7 +10938,7 @@
     \ with drifting coefficients and multivariate stochastic volatility. The coefficients\
     \ are assumed to follow \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=14647568290229216931&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14647568290229216931
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0165176518304452
 - id: 844
@@ -10953,7 +10953,7 @@
     \ implement than maximum likelihood approaches, that require simulation-based\
     \ inference methods. We develop a broad \u2026"
   journal: degruyter.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9113009446801138941&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9113009446801138941
   category: Economics
   doi: https://www.degruyter.com/document/doi/10.1515/jem-2014-0019/html
 - id: 845
@@ -10998,7 +10998,7 @@
     \ simulation-based inference procedures to such settings, we construct a novel\
     \ identification argument (see Section 2) that \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=12125491243104568118&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12125491243104568118
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407618300447
 - id: 848
@@ -11012,7 +11012,7 @@
     \ fluctuations, and hence several simulation-based inference procedures have been\
     \ proposed. We refer the reader to [59, \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=2784031925980286562&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2784031925980286562
   category: Engineering
   doi: https://link.springer.com/chapter/10.1007/978-3-319-21296-8_2
 - id: 849
@@ -11039,7 +11039,7 @@
     \ empirical settings of interest\u2014ranging from the close ties of friendship\
     \ and cohabitation to the wider ties of regular \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=5675563331655262614&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5675563331655262614
   category: Social Science
   doi: https://www.tandfonline.com/doi/abs/10.1080/0022250X.2014.994621
 - id: 852
@@ -11082,7 +11082,7 @@
     \ economics, and macroeconomics. Yet no exact likelihood analysis of these models\
     \ has been \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=16769168837231915789&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16769168837231915789
   category: Statistics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1468-0262.2004.00541.x
 - id: 856
@@ -11110,7 +11110,7 @@
     \ and many improved techniques are now available [69]. Active learning using Bayesian\
     \ optimization can ensure that \u2026"
   journal: royalsocietypublishing.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7894898294285121170&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7894898294285121170
   category: Geography
   doi: https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2020.0098
 - id: 858
@@ -11124,7 +11124,7 @@
     \ include the sequential neural likelihood (Papamakarios et al., 2019), which\
     \ presents a likelihood-free inference model \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=11803191662456509615&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11803191662456509615
   category: Computer Science
   doi: http://proceedings.mlr.press/08/ward20a.html
 - id: 859
@@ -11138,7 +11138,7 @@
     \ so we will follow the orthogonal approach of extracting fundamental QCD parameters\
     \ using simulation-based inference. \u2026"
   journal: scipost.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1730947140420276046&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1730947140420276046
   category: Physics
   doi: https://www.scipost.org/10.21468/SciPostPhys.10.6.126?acad_field_slug=astronomy
 - id: 860
@@ -11153,7 +11153,7 @@
     \ using an MCMC independence sampler with the approximate model as proposal generator.\
     \ Hence, Bayesian \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7724213965444143114&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7724213965444143114
   category: Mathematics
   doi: https://ieeexplore.ieee.org/abstract/document/7147792/
 - id: 861
@@ -11167,7 +11167,7 @@
     \ In this analysis, we will use the GHK simulator to approximate the probability.\
     \ The GHK simulator utilizes a sequence \u2026"
   journal: diva-portal.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9980973639412377654&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9980973639412377654
   category: Economics
   doi: https://www.diva-portal.org/smash/record.jsf?pid=diva2:129254
 - id: 862
@@ -11183,7 +11183,7 @@
     \ algorithms such as MCMC has been hampered by the slowness of the physical forward\
     \ model and \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1370452525943263757&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1370452525943263757
   arxiv_id: '2010.04156'
   arxiv_category_tag: astro-ph.IM
   category: Astrophysics
@@ -11198,7 +11198,7 @@
     \ choice models are computationally intensive indeed, notably because of the simulation-based\
     \ inference, advanced \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=3145283038374567780&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3145283038374567780
   category: Computer Science
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9574.2006.00317.x
 - id: 864
@@ -11212,7 +11212,7 @@
     \ theory and include the subclass of all max-stable processes. They allow for\
     \ a constructive representation \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=17751881239051181197&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17751881239051181197
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S2452306222000156
 - id: 865
@@ -11226,7 +11226,7 @@
     \ reestimation over the out-of-\u2026 It is specifically designed to avoid simulation-based\
     \ inference and produces predictions in \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=10075863782628120972&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10075863782628120972
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/joes.12410
 - id: 866
@@ -11255,7 +11255,7 @@
     \ allows us to compare \u2026 Even for the simple models in the present work,\
     \ simulation-based inference is computationally \u2026"
   journal: frontiersin.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9135110035439708173&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9135110035439708173
   category: Statistics
   doi: https://www.frontiersin.org/articles/10.3389/fmicb.2018.01529/full
 - id: 870
@@ -11271,7 +11271,7 @@
     \ hopeless and precludes many interesting applications in the rapidly expanding\
     \ field of simulation-based inference (\u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15975316589257452490&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15975316589257452490
   arxiv_id: '2301.11873'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -11287,7 +11287,7 @@
     \ of Common Statistical Knowledge, and included in many high school curricula\
     \ that include simulation-based inference. \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=10538669006220499919&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10538669006220499919
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2018.1496806
 - id: 872
@@ -11302,7 +11302,7 @@
     \ inference approach detailed below) is an interesting alternative to the estimation\
     \ of more complex models \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=10208744963870049520&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10208744963870049520
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S2452306218300947
 - id: 873
@@ -11317,7 +11317,7 @@
     \ complex models provide a third option of unifying multiple processes and multiple\
     \ data types across different scales (\u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=3634378330425683983&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3634378330425683983
   category: Ecology
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1111/1755-0998.13514
 - id: 874
@@ -11332,7 +11332,7 @@
     \ inference approaches such as simulated maximum-likelihood methods and Markov\
     \ chain Monte Carlo \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6604037882356772673&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6604037882356772673
   category: Genetics
   doi: 10.1101/2020.07.21.213769
 - id: 875
@@ -11345,7 +11345,7 @@
     \ simulation-based inference\u2026 - or simulation-based inference, which are\
     \ treated as non-perceptual, cognitive processes. \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=16552318376882922201&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16552318376882922201
   category: Social Science
   doi: https://www.sciencedirect.com/science/article/pii/S1053810015000781
 - id: 876
@@ -11360,7 +11360,7 @@
     \ simulation-based inference, where accurate and reliable simulations can be used\
     \ to perform inference over statistics whose \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8621876129686928991&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8621876129686928991
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.3847/1538-4357/ac7d4b/meta
 - id: 877
@@ -11374,7 +11374,7 @@
     \ it provides the basis for simulation-based inference procedures to be examined\
     \ in Section 3.5. \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=1910567298763369213&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1910567298763369213
   category: Computer Science
   doi: https://www.sciencedirect.com/science/article/pii/S0306457306001944
 - id: 878
@@ -11388,7 +11388,7 @@
     Hastings (MH) and Gibbs Sampling (GS), are by now the most widely used methods\
     \ for simulation\u2013 based inference in \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=8075448290544912062&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8075448290544912062
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11222-008-9108-5
 - id: 879
@@ -11401,7 +11401,7 @@
     \ rank P-splines of Eilers and Marx (1996) for stochastic simulation-based inference\
     \ with GAMs, while the reduced \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=7416790070387732473&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7416790070387732473
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s11749-020-00711-5
 - id: 880
@@ -11416,7 +11416,7 @@
     \ integrals are mapped into conditional expectations and estimated by the means\
     \ of simulation samples. \u2026"
   journal: royalsocietypublishing.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10687840113279456847&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10687840113279456847
   category: Economics
   doi: https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2002.0994
 - id: 881
@@ -11430,7 +11430,7 @@
     \ validity of the group behavior when the analytical expression for moment conditions\
     \ is fairly complicated. \u2026"
   journal: macau.uni-kiel.de
-  citation_backlink: https://scholar.google.com/scholar?cites=122343943744069098&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=122343943744069098
   category: Economics
   doi: https://macau.uni-kiel.de/receive/diss_mods_00010007?lang=de
 - id: 882
@@ -11443,7 +11443,7 @@
     \ (and variable-)dimensional reweighting functions, which can be viewed as an\
     \ application of simulation-based inference (\u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=1818638594766876122&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1818638594766876122
   category: Computer Science
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.105.076015
 - id: 883
@@ -11456,7 +11456,7 @@
     \ simulations using the asymptotic critical values, except for M C S U C 1 t which\
     \ uses simulation based inference. All \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=11921300322558332918&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11921300322558332918
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0378426619300251
 - id: 884
@@ -11471,7 +11471,7 @@
     \ fields of science. Theory validation, parameter estimation, and prediction all\
     \ require model calibration and \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=1009602155830620117&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1009602155830620117
   category: Statistics
   doi: https://www.sciencedirect.com/science/article/pii/S0021999122006052
 - id: 885
@@ -11485,7 +11485,7 @@
     \ developments of the 1990s. Gradually, advances in Bayesian methodology and software\
     \ have made Bayesian \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=3239182095402103241&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3239182095402103241
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2020.1847008
 - id: 886
@@ -11499,7 +11499,7 @@
     \ be used to perform simulation-based inference and model selection in a Bayesian\
     \ framework (see Roux et al., this \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=13870314944426143355&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13870314944426143355
   category: Quantitative Biology
   doi: https://link.springer.com/protocol/10.1007/978-1-0716-2561-3_16
 - id: 888
@@ -11526,7 +11526,7 @@
     \ inference or simulationbased inference [4, 11, 12]. Recent progress in this\
     \ direction includes likelihood-free inference \u2026"
   journal: epj-conferences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9190994460612255276&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9190994460612255276
   category: Physics
   doi: https://www.epj-conferences.org/articles/epjconf/abs/2021/05/epjconf_chep2021_03059/epjconf_chep2021_03059.html
 - id: 890
@@ -11540,7 +11540,7 @@
     \ involving both birth and death rates in the drift and diffusion coefficients,\
     \ and not only propose two indirect \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=4799356853302582076&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4799356853302582076
   category: Mathematics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610926.2015.1019152
 - id: 891
@@ -11554,7 +11554,7 @@
     \ of simulation-based inference [10]. Recently techniques have been developed\
     \ to enable the use of existing stochastic \u2026"
   journal: strathprints.strath.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=9658505759141411301&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9658505759141411301
   doi: https://strathprints.strath.ac.uk/76217/
 - id: 892
   created_at: 2023-05-22 16:58:08.865728
@@ -11594,7 +11594,7 @@
     \ at SNU and HU are conducted in a US university - MIT in this case - and by using\
     \ a simulation-based inference \u2026"
   journal: kmbase.medric.or.kr
-  citation_backlink: https://scholar.google.com/scholar?cites=15566153095199045046&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15566153095199045046
   doi: https://kmbase.medric.or.kr/KMID/1011120160090030001
 - id: 895
   created_at: 2023-05-22 16:58:08.992349
@@ -11632,7 +11632,7 @@
     \ and applied. Theoretical topics include methodology papers on panel data probit\
     \ models, treatment models, error \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=6421898489543695042&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6421898489543695042
   category: Economics
   doi: https://books.google.com/books?hl=en&lr=&id=WzaqYt037M4C&oi=fnd&pg=PA1&dq=%22simulation-based%2Binference%22&ots=CscQJuyt9c&sig=_54iDG-LFVIgC5JNc9DawXaEfgs
 - id: 899
@@ -11659,7 +11659,7 @@
     \ of simulation-based inference algorithms which do not require numerical evaluation\
     \ of likelihoods. However, a \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=1721220439917678089&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1721220439917678089
   category: Statistics
   doi: http://proceedings.mlr.press/30/lueckmann21a.html
 - id: 902
@@ -11675,7 +11675,7 @@
     \ that a) are compatible with prior knowledge and b) match empirical observations.\
     \ Importantly, SBI does not seek to \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3698931000465690656&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3698931000465690656
   arxiv_id: '2007.09114'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -11689,7 +11689,7 @@
     \ has made possible many powerful new simulation-based inference techniques, which\
     \ enable the \u2026"
   journal: nature.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12629169593661058740&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12629169593661058740
   category: Physics
   doi: https://www.nature.com/articles/s42254-021-00305-6
 - id: 904
@@ -11704,7 +11704,7 @@
     \ accurate as SNLE and SNRE, while being substantially faster at inference as\
     \ they do not require MCMC sampling. In \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=16337891944937937425&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16337891944937937425
   arxiv_id: '2203.04176'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -11719,7 +11719,7 @@
     \ from the empirical data using resampling techniques, simulation based inference\
     \ on the agent based model for given \u2026"
   journal: core.ac.uk
-  citation_backlink: https://scholar.google.com/scholar?cites=1477904798158622134&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1477904798158622134
   category: Quantitative Finance
   doi: https://core.ac.uk/download/pdf/190293161.pdf
 - id: 907
@@ -11733,7 +11733,7 @@
     \ randomization\u2010based statistical inference as a prominent feature in introductory\
     \ statistics courses. We \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=643565023667297413&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=643565023667297413
   category: Education
   doi: https://wires.onlinelibrary.wiley.com/doi/abs/10.1002/wics.1302
 - id: 908
@@ -11748,7 +11748,7 @@
     \ tests) has been advocated recently with the goal of improving student understanding\
     \ of statistical inference, as well \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=15010801588867838552&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15010801588867838552
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2016.1223529
 - id: 909
@@ -11762,7 +11762,7 @@
     \ of models appear, both of which are prone to misspecification: the simulator\
     \ itself and machine learning surrogates. \u2026"
   journal: World Scientific
-  citation_backlink: https://scholar.google.com/scholar?cites=18045109966055374374&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=18045109966055374374
   category: Physics
   doi: https://www.worldscientific.com/doi/abs/10.1142/9789811234033_0016
 - id: 910
@@ -11776,7 +11776,7 @@
     \ by only requiring access to simulations produced by the model. Previously, Fengler\
     \ et al. introduced likelihood \u2026"
   journal: elifesciences.org
-  citation_backlink: https://scholar.google.com/scholar?cites=882615692154782472&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=882615692154782472
   category: Cognitive Science
   doi: https://elifesciences.org/articles/77220
 - id: 911
@@ -11791,7 +11791,7 @@
     \ inference methods are becoming increasingly used for inference in complex systems,\
     \ due to their relative \u2026"
   journal: projecteuclid.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1800340886933687610&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1800340886933687610
   category: Epidemiology
   doi: https://projecteuclid.org/journals/statistical-science/volume-33/issue-1/Approximate-Bayesian-Computation-and-Simulation-Based-Inference-for-Complex-Stochastic/10.1214/17-STS618
 - id: 912
@@ -11807,7 +11807,7 @@
     \ on stochastic models for which we can generate samples, but not compute likelihoods.\
     \ Like SBI algorithms, generative \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15349002435008264502&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15349002435008264502
   arxiv_id: '2203.06481'
   arxiv_category_tag: stat.ML
   category: Statistics
@@ -11823,7 +11823,7 @@
     \ of functional limitations using seven waves (1991\u20131997) of the British\
     \ Household Panel Survey (BHPS). \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=5502521948616602939&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5502521948616602939
   category: Statistics
   doi: https://link.springer.com/article/10.1007/s00181-003-0189-x
 - id: 914
@@ -11837,7 +11837,7 @@
     \ machine learning technique for analyzing data in cosmological surveys. Despite\
     \ continual improvements to \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=1774884986639649625&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1774884986639649625
   category: Astrophysics
   doi: https://iopscience.iop.org/article/10.1088/2632-2153/acbb53/meta
 - id: 915
@@ -11852,7 +11852,7 @@
     \ in particular density estimation techniques using normalizing flows, in order\
     \ to characterize the contribution of \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=11093087193446363998&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11093087193446363998
   category: Astrophysics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.105.063017
 - id: 916
@@ -11867,7 +11867,7 @@
     \ inference in the natural sciences. Although the procedure generalizes to many\
     \ domains, we apply our \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12029625523818675865&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12029625523818675865
   category: Astrophysics
   doi: https://academic.oup.com/mnras/article-abstract/507/2/1999/6346560
 - id: 917
@@ -11882,7 +11882,7 @@
     \ function, as is typical in scientific domains relying on computer simulations.\
     \ We investigate how the \u2026"
   journal: proceedings.mlr.press
-  citation_backlink: https://scholar.google.com/scholar?cites=13205365164554212971&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13205365164554212971
   category: Neuroscience
   doi: https://proceedings.mlr.press/30/vandegar21a.html?ref=https://githubhelp.com
 - id: 918
@@ -11897,7 +11897,7 @@
     \ problem within this simulation-based inference framework, we \u2026 the application\
     \ of a simulation-based inference \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9612118677123637824&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9612118677123637824
   category: Astrophysics
   doi: https://academic.oup.com/mnras/article-abstract/501/3/4080/6043218
 - id: 919
@@ -11913,7 +11913,7 @@
     \ (denoted \u201Cearly-SBI\u201D), and (3) Students using a full version of a\
     \ simulation-based inference curriculum (denoted \u201CSBI\u201D). \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=17339111915076874922&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17339111915076874922
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/10691898.2018.1473061
 - id: 920
@@ -11928,7 +11928,7 @@
     \ contain a wealth of information about the reionization of the intergalactic\
     \ medium by astrophysical sources. \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14381166610540539011&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14381166610540539011
   category: Statistics
   doi: https://iopscience.iop.org/article/10.3847/1538-4357/ac457d/meta
 - id: 922
@@ -11942,7 +11942,7 @@
     \ the relationship between a binary outcome and a set of potential predictors.\
     \ When analyzing binary data, it often \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=9320708489341727215&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9320708489341727215
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/03610918.2014.950743
 - id: 923
@@ -11956,7 +11956,7 @@
     \ and discusses simulation-based inference for clustered point patterns. Section\
     \ 4.7 deals with different aspects of \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=3083092963201418161&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3083092963201418161
   category: Statistics
   doi: https://link.springer.com/chapter/10.1007/978-0-387-21811-3_4
 - id: 924
@@ -11971,7 +11971,7 @@
     \ inference (SBI; for a recent review, see Cranmer, Brehmer & Louppe 2020) that\
     \ allows us to model the \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=1010069005261090290&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=1010069005261090290
   category: Astrophysics
   doi: https://academic.oup.com/mnras/article-abstract/511/4/5689/6460498
 - id: 925
@@ -11985,7 +11985,7 @@
     \ of a moving average process, including the estimators ini tially proposed by\
     \ Galbraith and Zinde-Walsh [1994] \u2026"
   journal: JSTOR
-  citation_backlink: https://scholar.google.com/scholar?cites=15037270854113414014&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15037270854113414014
   category: Statistics
   doi: https://www.jstor.org/stable/20076364
 - id: 926
@@ -11999,7 +11999,7 @@
     \ inspected intermittently so that a lifetime is observed to lie between two successive\
     \ times. In settings where only \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=10641664171209954199&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10641664171209954199
   category: Statistics
   doi: https://academic.oup.com/biomet/article-abstract/93/3/671/380715
 - id: 927
@@ -12013,7 +12013,7 @@
     \ known as simulation-based inference or likelihood-free \u2026 One such simulation-based\
     \ inference method considered in \u2026"
   journal: ieeexplore.ieee.org
-  citation_backlink: https://scholar.google.com/scholar?cites=13545793990304509683&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=13545793990304509683
   category: Computer Science
   doi: https://ieeexplore.ieee.org/abstract/document/9325369/
 - id: 928
@@ -12028,7 +12028,7 @@
     \ inference (SBI) \u2026 For a full review of simulation-based inference and other\
     \ methods therein, we refer the \u2026"
   journal: APS
-  citation_backlink: https://scholar.google.com/scholar?cites=10127766878010992473&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10127766878010992473
   category: Physics
   doi: https://journals.aps.org/prd/abstract/10.1103/PhysRevD.106.115016
 - id: 929
@@ -12043,7 +12043,7 @@
     \ method that enables integrationless marginal posterior estimation over arbitrary\
     \ parameter subspaces. Through our \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=11785075797777485108&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=11785075797777485108
   arxiv_id: '2110.00449'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -12059,7 +12059,7 @@
     \ methods, in particular, density estimation techniques, to the predictions of\
     \ the set of parameters of strong lensing \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6363839371958567842&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6363839371958567842
   arxiv_id: '2112.05278'
   arxiv_category_tag: astro-ph.CO
   category: Astrophysics
@@ -12075,7 +12075,7 @@
     \ the virtual epileptic patient (SBI-VEP) model, which only requires forward simulations,\
     \ enabling us to amortize posterior \u2026"
   journal: medrxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=15588430923589677814&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15588430923589677814
   category: Neuroscience
   doi: https://www.medrxiv.org/content/10.1101/2022.06.02.22275860
 - id: 932
@@ -12090,7 +12090,7 @@
     \ approximations, involving the use of asymptotic distributions or bootstrap techniques.\
     \ After \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=3438218403729587737&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3438218403729587737
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0304407605001752
 - id: 933
@@ -12105,7 +12105,7 @@
     \ to model and sample \u2026 design new transform samplers to perform simulation-based\
     \ inference. Our RGM sampler can \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=9046357801084229961&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9046357801084229961
   arxiv_id: '2109.14090'
   arxiv_category_tag: stat.ME
   category: Statistics
@@ -12121,7 +12121,7 @@
     \ in this work is targeted toward three such platforms: the Nvidia Tesla V100\
     \ GPU, the Google V2 TPU, and \u2026"
   journal: dl.acm.org
-  citation_backlink: https://scholar.google.com/scholar?cites=14861113835188738656&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14861113835188738656
   category: Epidemiology
   doi: https://dl.acm.org/doi/abs/10.1145/3471188
 - id: 935
@@ -12136,7 +12136,7 @@
     \ simulation based inference approach to evaluate the ability to calibrate the\
     \ emulator to randomly selected simulations \u2026"
   journal: mdpi.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2115078919199993382&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2115078919199993382
   category: Physics
   doi: https://www.mdpi.com/1409460
 - id: 937
@@ -12153,7 +12153,7 @@
     \ in simulation-based inference, and explore its potential as a novel venue for\
     \ model calibration to support the \u2026"
   journal: arxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=8515725940956867034&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=8515725940956867034
   arxiv_id: '2005.07062'
   arxiv_category_tag: cs.LG
   category: Computer Science
@@ -12168,7 +12168,7 @@
     \ inference for BSA mapping (SIBSAM). This method identifies significant QTL and\
     \ estimates their genomic confidence \u2026"
   journal: academic.oup.com
-  citation_backlink: https://scholar.google.com/scholar?cites=4127708505602156434&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4127708505602156434
   category: Genetics
   doi: https://academic.oup.com/genetics/article-abstract/204/3/1295/6066352
 - id: 939
@@ -12182,7 +12182,7 @@
     \ by simulation-based inference. Then classical simulation methods are introduced.\
     \ These are designed to approximate \u2026"
   journal: Wiley Online Library
-  citation_backlink: https://scholar.google.com/scholar?cites=10448735658531007844&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10448735658531007844
   category: Economics
   doi: https://onlinelibrary.wiley.com/doi/abs/10.1002/hec.811
 - id: 940
@@ -12197,7 +12197,7 @@
     \ neural network paired with a simulation-based inference technique to estimate\
     \ the position of the spot of \u2026"
   journal: spiedigitallibrary.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3284902716705718256&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3284902716705718256
   category: Engineering
   doi: https://www.spiedigitallibrary.org/journals/Journal-of-Astronomical-Telescopes-Instruments-and-Systems/volume-9/issue-2/025002/Lightweight-starshade-position-sensing-with-convolutional-neural-networks-and-simulation/10.1117/1.JATIS.9.2.025002
 - id: 941
@@ -12212,7 +12212,7 @@
     \ challenge with applications from epidemiology to molecular dynamics. Here we\
     \ show a simple approach in the \u2026"
   journal: iopscience.iop.org
-  citation_backlink: https://scholar.google.com/scholar?cites=3670954072331796454&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=3670954072331796454
   category: Statistics
   doi: https://iopscience.iop.org/article/10.1088/2632-2153/ac6286/meta
 - id: 942
@@ -12226,7 +12226,7 @@
     \ of selecting the type of dependence structure that best fits the empirical data\
     \ and of ascertaining the robustness of the \u2026"
   journal: degruyter.com
-  citation_backlink: https://scholar.google.com/scholar?cites=9604518993135764542&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=9604518993135764542
   category: Quantitative Finance
   doi: https://www.degruyter.com/document/doi/10.5018/economics-ejournal.ja.2014-39/html
 - id: 943
@@ -12242,7 +12242,7 @@
     \ bears the potential to systematically reconstruct complex differentiation processes\
     \ but remains challenging \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=4133967817387495248&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4133967817387495248
   category: Bioinformatics
   doi: 10.1101/2020.12.21.423801
 - id: 944
@@ -12256,7 +12256,7 @@
     \ across grade levels and \u2026 , including, but not limited to, simulation-based\
     \ inference. In this paper, we will summarize \u2026"
   journal: isi-stats.com
-  citation_backlink: https://scholar.google.com/scholar?cites=2697447519676347855&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=2697447519676347855
   category: Education
   doi: http://www.isi-stats.com/isi/presentations/ICOTS2018-5.pdf
 - id: 945
@@ -12271,7 +12271,7 @@
     \ statistics program for all students, and that simulation-based inference \u2026\
     \ of simulation-based inference on the \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=7365430305291695766&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7365430305291695766
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/00031305.2015.1081619
 - id: 946
@@ -12285,7 +12285,7 @@
     \ has become increasingly common, particularly for latent variable models. The\
     \ reason is that such models \u2026"
   journal: books.google.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12673945401665934438&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12673945401665934438
   category: Statistics
   doi: https://books.google.com/books?hl=en&lr=&id=xs55E7FsMHMC&oi=fnd&pg=PA466&dq=%22simulation-based%2Binference%22&ots=gpgmU4XsEn&sig=gxZy1KZtGMBZTtVtES9ABmxRsHY
 - id: 947
@@ -12300,7 +12300,7 @@
     \ topics (eg, descriptive statistics). Our results indicate that most recently,\
     \ students in simulation-based inference courses \u2026"
   journal: digitalcollections.dordt.edu
-  citation_backlink: https://scholar.google.com/scholar?cites=17448157013823514512&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=17448157013823514512
   category: Mathematics
   doi: https://digitalcollections.dordt.edu/faculty_work/1261/
 - id: 948
@@ -12315,7 +12315,7 @@
     \ inference with D/C-based models. The fact remains that two-step MSL is currently\
     \ the method of choice for such \u2026"
   journal: Elsevier
-  citation_backlink: https://scholar.google.com/scholar?cites=5948051948734780649&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=5948051948734780649
   category: Economics
   doi: https://www.sciencedirect.com/science/article/pii/S0167947307003623
 - id: 949
@@ -12331,7 +12331,7 @@
     \ to the determination of \u2026 the appropriate computational framework for simulation-based\
     \ inference and to apply it to \u2026"
   journal: biorxiv.org
-  citation_backlink: https://scholar.google.com/scholar?cites=10567720336663521481&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10567720336663521481
   category: Evolutionary biology
   doi: 10.1101/2021.09.30.462581
 - id: 950
@@ -12345,7 +12345,7 @@
     \ based on large-sample approximations, involving the use of asymptotic distributions\
     \ or bootstrap techniques. After \u2026"
   journal: papyrus.bib.umontreal.ca
-  citation_backlink: https://scholar.google.com/scholar?cites=10314528240884419858&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=10314528240884419858
   category: Statistics
   doi: http://papyrus.bib.umontreal.ca/xmlui/handle/1866/541
 - id: 952
@@ -12359,7 +12359,7 @@
     \ inference technique for simultaneous autoregression models (see eg Cressie 1993,\
     \ Sections 6.3 and 6.8). These are \u2026"
   journal: Springer
-  citation_backlink: https://scholar.google.com/scholar?cites=4494030424274808811&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=4494030424274808811
   category: Physics
   doi: https://link.springer.com/article/10.1023/A:1014830401806
 - id: 953
@@ -12374,7 +12374,7 @@
     \ after engaging in simulation-based inference activities. \u2026 that incorporating\
     \ simulation-based inference into traditional \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=16118906085613312446&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=16118906085613312446
   category: Education
   doi: https://www.tandfonline.com/doi/abs/10.1080/19477503.2018.1438869
 - id: 954
@@ -12389,7 +12389,7 @@
     \ showed the most evidence of a positive effect we ran similar models (see Model\
     \ Equation above) for each of the \u2026"
   journal: iase-web.org
-  citation_backlink: https://scholar.google.com/scholar?cites=7282203935240776240&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=7282203935240776240
   category: Education
   doi: https://iase-web.org/icots/10/proceedings/pdfs/ICOTS10_C174.pdf
 - id: 955
@@ -12404,7 +12404,7 @@
     \ and simulation-based inference curricula we first needed to prepare a curriculum\
     \ for each approach. Both curric\u2026"
   journal: escholarship.org
-  citation_backlink: https://scholar.google.com/scholar?cites=6966691946674562777&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=6966691946674562777
   category: Education
   doi: https://escholarship.org/uc/item/0wm523b0
 - id: 956
@@ -12418,7 +12418,7 @@
     \ allows for simulation-based inference techniques which can \u2026 to implement\
     \ simulation-based inference techniques such as \u2026"
   journal: papyrus.bib.umontreal.ca
-  citation_backlink: https://scholar.google.com/scholar?cites=14169503354278739665&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=14169503354278739665
   category: Quantitative Finance
   doi: https://papyrus.bib.umontreal.ca/xmlui/bitstream/handle/1866/181/a1.3g102.pdf?sequence=1
 - id: 957
@@ -12445,7 +12445,7 @@
     \ of some (coded) predictor variables x = (x 1 , x 2 ,..., x k ) that optimize\
     \ the expected value of a response \u2026"
   journal: Taylor & Francis
-  citation_backlink: https://scholar.google.com/scholar?cites=15039470196978940988&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=15039470196978940988
   category: Statistics
   doi: https://www.tandfonline.com/doi/abs/10.1080/16843703.2007.11673167
 - id: 959
@@ -12476,7 +12476,7 @@
     \ introductory statistics \u2026 students, comparing simulation-based inference\
     \ (SBI) and non-simulation-based inference (\u2026"
   journal: isi-stats.com
-  citation_backlink: https://scholar.google.com/scholar?cites=12762485340581241026&as_sdt=2005&sciodt=0,5&hl=en&num=20
+  citation_backlink: https://scholar.google.com/scholar?cites=12762485340581241026
   category: Education
   doi: http://www.isi-stats.com/isi/presentations/ICOTS2018-6.pdf
 - id: 961

--- a/backend/database.py
+++ b/backend/database.py
@@ -84,7 +84,7 @@ def write_papers(papers: list[Union[Paper, dict]]) -> None:
     """Write the papers to the YAML database."""
 
     if isinstance(papers[0], Paper):
-        papers = [paper.dict(exclude_none=True) for paper in papers]
+        papers = [paper.model_dump(exclude_none=True) for paper in papers]
 
     with open(PAPERS_YAML, "w") as f:
         print(f"Updating YAML database: {PAPERS_YAML}...")

--- a/working.ipynb
+++ b/working.ipynb
@@ -9,6 +9,88 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Improve citation backlink to avoid unnecessary update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from backend.database import get_papers, write_papers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "papers = get_papers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for paper in papers:\n",
+    "    link = paper.citation_backlink\n",
+    "    if not link:\n",
+    "        continue\n",
+    "\n",
+    "    if not link.startswith(\"https://scholar.google.com/scholar?\"):\n",
+    "        continue\n",
+    "\n",
+    "    splitted = link.split(\"&as_sdt\")\n",
+    "    paper.citation_backlink = splitted[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for paper in papers:\n",
+    "    link = paper.citation_backlink\n",
+    "    if not link:\n",
+    "        continue\n",
+    "\n",
+    "    print(paper.title)\n",
+    "    print(link)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updating YAML database: /sim-based-inference/backend/data/papers.yaml...\n"
+     ]
+    }
+   ],
+   "source": [
+    "write_papers(papers)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The `citation_backlink` we obtain from SERP API includes certain time-sensitive parameters that aren't required. These parameters trigger unnecessary alterations each time the crawler seeks an update, leading to excessive and redundant modifications by the bot. If we remove these time-dependent parameters, the functionality will remain intact, but without the bot needing to constantly updating the record.